### PR TITLE
feat(Toolbar,OverflowMenu): support responsive height vis breakpoints

### DIFF
--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -12,7 +12,7 @@ export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   children?: any;
   /** Additional classes added to the OverflowMenu. */
   className?: string;
-  /** Indicates breakpoint at which to switch between expanded and collapsed states */
+  /** Indicates breakpoint at which to switch between expanded and collapsed states. The "sm" breakpoint does not apply to vertical overflow menus. */
   breakpoint: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
   /** A container reference to base the specified breakpoint on instead of the viewport width. */
   breakpointReference?: HTMLElement | (() => HTMLElement) | React.RefObject<any>;
@@ -102,6 +102,12 @@ class OverflowMenu extends Component<OverflowMenuProps, OverflowMenuState> {
 
   handleResizeHeight = () => {
     const breakpointHeight = globalHeightBreakpoints[this.props.breakpoint];
+    if (breakpointHeight === 0) {
+      // eslint-disable-next-line no-console
+      console.warn('The "sm" breakpoint does not apply to vertical overflow menus.');
+      return;
+    }
+
     if (!breakpointHeight) {
       // eslint-disable-next-line no-console
       console.error('OverflowMenu will not be visible without a valid breakpoint.');

--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -5,7 +5,7 @@ import { OverflowMenuContext } from './OverflowMenuContext';
 import { debounce } from '../../helpers/util';
 import { globalWidthBreakpoints, globalHeightBreakpoints } from '../../helpers/constants';
 import { getResizeObserver } from '../../helpers/resizeObserver';
-import { PickOptional } from 'src/helpers';
+import { PickOptional } from '../../helpers/typeUtils';
 
 export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   /** Any elements that can be rendered in the menu */

--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -3,18 +3,21 @@ import styles from '@patternfly/react-styles/css/components/OverflowMenu/overflo
 import { css } from '@patternfly/react-styles';
 import { OverflowMenuContext } from './OverflowMenuContext';
 import { debounce } from '../../helpers/util';
-import { globalWidthBreakpoints } from '../../helpers/constants';
+import { globalWidthBreakpoints, globalHeightBreakpoints } from '../../helpers/constants';
 import { getResizeObserver } from '../../helpers/resizeObserver';
+import { PickOptional } from 'src/helpers';
 
 export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   /** Any elements that can be rendered in the menu */
   children?: any;
   /** Additional classes added to the OverflowMenu. */
   className?: string;
-  /** Indicates breakpoint at which to switch between horizontal menu and vertical dropdown */
+  /** Indicates breakpoint at which to switch between expanded and collapsed states */
   breakpoint: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
   /** A container reference to base the specified breakpoint on instead of the viewport width. */
   breakpointReference?: HTMLElement | (() => HTMLElement) | React.RefObject<any>;
+  /** Indicates the overflow menu orientation is vertical and should respond to height changes instead of width. */
+  isVertical?: boolean;
 }
 
 export interface OverflowMenuState extends React.HTMLProps<HTMLDivElement> {
@@ -24,6 +27,11 @@ export interface OverflowMenuState extends React.HTMLProps<HTMLDivElement> {
 
 class OverflowMenu extends Component<OverflowMenuProps, OverflowMenuState> {
   static displayName = 'OverflowMenu';
+
+  static defaultProps: PickOptional<OverflowMenuProps> = {
+    isVertical: false
+  };
+
   constructor(props: OverflowMenuProps) {
     super(props);
     this.state = {
@@ -69,6 +77,15 @@ class OverflowMenu extends Component<OverflowMenuProps, OverflowMenuState> {
   }
 
   handleResize = () => {
+    const { isVertical } = this.props;
+    if (isVertical) {
+      this.handleResizeHeight();
+    } else {
+      this.handleResizeWidth();
+    }
+  };
+
+  handleResizeWidth = () => {
     const breakpointWidth = globalWidthBreakpoints[this.props.breakpoint];
     if (!breakpointWidth) {
       // eslint-disable-next-line no-console
@@ -83,14 +100,29 @@ class OverflowMenu extends Component<OverflowMenuProps, OverflowMenuState> {
     }
   };
 
+  handleResizeHeight = () => {
+    const breakpointHeight = globalHeightBreakpoints[this.props.breakpoint];
+    if (!breakpointHeight) {
+      // eslint-disable-next-line no-console
+      console.error('OverflowMenu will not be visible without a valid breakpoint.');
+      return;
+    }
+
+    const relativeHeight = this.state.breakpointRef ? this.state.breakpointRef.clientHeight : window.innerHeight;
+    const isBelowBreakpoint = relativeHeight < breakpointHeight;
+    if (this.state.isBelowBreakpoint !== isBelowBreakpoint) {
+      this.setState({ isBelowBreakpoint });
+    }
+  };
+
   handleResizeWithDelay = debounce(this.handleResize, 250);
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { className, breakpoint, children, breakpointReference, ...props } = this.props;
+    const { className, breakpoint, children, breakpointReference, isVertical, ...props } = this.props;
 
     return (
-      <div {...props} className={css(styles.overflowMenu, className)}>
+      <div {...props} className={css(styles.overflowMenu, isVertical && styles.modifiers.vertical, className)}>
         <OverflowMenuContext.Provider value={{ isBelowBreakpoint: this.state.isBelowBreakpoint }}>
           {children}
         </OverflowMenuContext.Provider>

--- a/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -79,4 +79,22 @@ describe('OverflowMenu', () => {
 
     expect(resizeObserver).toHaveBeenCalledWith(containerRef.current, expect.any(Function));
   });
+
+  test(`applies ${styles.modifiers.vertical} when isVertical is passed`, () => {
+    render(<OverflowMenu breakpoint="md" isVertical data-testid="test-id" />);
+    expect(screen.getByTestId('test-id')).toHaveClass(styles.modifiers.vertical);
+  });
+
+  test('warns when using "sm" breakpoint and isVertical is passed', () => {
+    const warnMock = jest.fn() as any;
+    const originalConsole = global.console;
+    global.console = { ...originalConsole, warn: warnMock } as any;
+
+    try {
+      render(<OverflowMenu breakpoint="sm" isVertical />);
+      expect(warnMock).toHaveBeenCalledWith('The "sm" breakpoint does not apply to vertical overflow menus.');
+    } finally {
+      global.console = originalConsole;
+    }
+  });
 });

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -27,7 +27,9 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 
 ```
 
-### Simple vertical (responsive)
+### Vertical
+
+Passing `isVertical` to `OverflowMenu` will change its behavior to respond to breakpoints based on window height instead of width.
 
 ```ts file="./OverflowMenuSimpleVertical.tsx"
 
@@ -63,8 +65,8 @@ You can change the container width in this example by adjusting the slider. As t
 
 ### Breakpoint on container height
 
-By passing in the `breakpointReference` and `isVertical` properties, the overflow menu's breakpoint will be relative to the height of the reference container rather than the viewport height.
+By passing in the `breakpointReference` and `isVertical` properties, the overflow menu's breakpoint will be determined relative to the height of the reference container rather than the window height.
 
-```ts file="./OverflowMenuBreakpointOnContainerHeight.tsx"
+```ts isFullscreen file="./OverflowMenuBreakpointOnContainerHeight.tsx"
 
 ```

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -27,6 +27,12 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 
 ```
 
+### Simple vertical (responsive)
+
+```ts file="./OverflowMenuSimpleVertical.tsx"
+
+```
+
 ### Group types
 
 ```ts file="./OverflowMenuGroupTypes.tsx"
@@ -45,12 +51,20 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 
 ```
 
-### Breakpoint on container
+### Breakpoint on container width
 
 By passing in the `breakpointReference` property, the overflow menu's breakpoint will be relative to the width of the reference container rather than the viewport width.
 
 You can change the container width in this example by adjusting the slider. As the container width changes, the overflow menu will change between a horizontal menu and a vertical dropdown despite the viewport width not changing.
 
 ```ts file="./OverflowMenuBreakpointOnContainer.tsx"
+
+```
+
+### Breakpoint on container height
+
+By passing in the `breakpointReference` and `isVertical` properties, the overflow menu's breakpoint will be relative to the height of the reference container rather than the viewport height.
+
+```ts file="./OverflowMenuBreakpointOnContainerHeight.tsx"
 
 ```

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainerHeight.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainerHeight.tsx
@@ -60,7 +60,7 @@ export const OverflowMenuBreakpointOnContainerHeight: React.FunctionComponent = 
     <>
       <div style={{ height: '100%', maxHeight: '400px' }}>
         <div>
-          <span id="overflowMenu-hasBreakpointOnContainer-height-slider-label">Current container width</span>:{' '}
+          <span id="overflowMenu-hasBreakpointOnContainer-height-slider-label">Current container height</span>:{' '}
           {containerHeight}%
         </div>
         <Slider
@@ -75,7 +75,7 @@ export const OverflowMenuBreakpointOnContainerHeight: React.FunctionComponent = 
         />
       </div>
       <div ref={containerRef} id="height-breakpoint-reference-container" style={containerStyles}>
-        <OverflowMenu breakpointReference={containerRef} breakpoint="sm">
+        <OverflowMenu breakpointReference={containerRef} breakpoint="sm" isVertical>
           <OverflowMenuContent>
             <OverflowMenuItem>Item 1</OverflowMenuItem>
             <OverflowMenuItem>Item 2</OverflowMenuItem>

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainerHeight.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainerHeight.tsx
@@ -1,0 +1,111 @@
+import { useRef, useState } from 'react';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem,
+  MenuToggle,
+  Slider,
+  SliderOnChangeEvent,
+  Dropdown,
+  DropdownList
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+
+export const OverflowMenuBreakpointOnContainerHeight: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [containerHeight, setContainerHeight] = useState(100);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onChange = (_event: SliderOnChangeEvent, value: number) => {
+    setContainerHeight(value);
+  };
+
+  const containerStyles = {
+    height: `${containerHeight}%`,
+    padding: '1rem',
+    borderWidth: '2px',
+    borderStyle: 'dashed'
+  };
+
+  const dropdownItems = [
+    <OverflowMenuDropdownItem itemId={0} key="item1" isShared>
+      Item 1
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={1} key="item2" isShared>
+      Item 2
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={2} key="item3" isShared>
+      Item 3
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={3} key="item4" isShared>
+      Item 4
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={4} key="item5" isShared>
+      Item 5
+    </OverflowMenuDropdownItem>
+  ];
+
+  return (
+    <>
+      <div style={{ height: '100%', maxHeight: '400px' }}>
+        <div>
+          <span id="overflowMenu-hasBreakpointOnContainer-height-slider-label">Current container width</span>:{' '}
+          {containerHeight}%
+        </div>
+        <Slider
+          value={containerHeight}
+          onChange={onChange}
+          max={100}
+          min={20}
+          step={20}
+          showTicks
+          showBoundaries={false}
+          aria-labelledby="overflowMenu-hasBreakpointOnContainer-height-slider-label"
+        />
+      </div>
+      <div ref={containerRef} id="height-breakpoint-reference-container" style={containerStyles}>
+        <OverflowMenu breakpointReference={containerRef} breakpoint="sm">
+          <OverflowMenuContent>
+            <OverflowMenuItem>Item 1</OverflowMenuItem>
+            <OverflowMenuItem>Item 2</OverflowMenuItem>
+            <OverflowMenuGroup>
+              <OverflowMenuItem>Item 3</OverflowMenuItem>
+              <OverflowMenuItem>Item 4</OverflowMenuItem>
+              <OverflowMenuItem>Item 5</OverflowMenuItem>
+            </OverflowMenuGroup>
+          </OverflowMenuContent>
+          <OverflowMenuControl>
+            <Dropdown
+              onSelect={onSelect}
+              toggle={(toggleRef) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  aria-label="Height breakpoint on container example overflow menu"
+                  variant="plain"
+                  onClick={onToggle}
+                  isExpanded={isOpen}
+                  icon={<EllipsisVIcon />}
+                />
+              )}
+              isOpen={isOpen}
+              onOpenChange={(isOpen) => setIsOpen(isOpen)}
+            >
+              <DropdownList>{dropdownItems}</DropdownList>
+            </Dropdown>
+          </OverflowMenuControl>
+        </OverflowMenu>
+      </div>
+    </>
+  );
+};

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainerHeight.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainerHeight.tsx
@@ -58,53 +58,51 @@ export const OverflowMenuBreakpointOnContainerHeight: React.FunctionComponent = 
 
   return (
     <>
-      <div style={{ height: '100%', maxHeight: '400px' }}>
-        <div>
-          <span id="overflowMenu-hasBreakpointOnContainer-height-slider-label">Current container height</span>:{' '}
-          {containerHeight}%
+      <span id="overflowMenu-hasBreakpointOnContainer-height-slider-label">Current container height</span>:{' '}
+      {containerHeight}%
+      <Slider
+        value={containerHeight}
+        onChange={onChange}
+        max={100}
+        min={20}
+        step={20}
+        showTicks
+        showBoundaries={false}
+        aria-labelledby="overflowMenu-hasBreakpointOnContainer-height-slider-label"
+      />
+      <div style={{ height: '100%' }}>
+        <div ref={containerRef} id="height-breakpoint-reference-container" style={containerStyles}>
+          <OverflowMenu breakpointReference={containerRef} breakpoint="md" isVertical>
+            <OverflowMenuContent>
+              <OverflowMenuItem>Item 1</OverflowMenuItem>
+              <OverflowMenuItem>Item 2</OverflowMenuItem>
+              <OverflowMenuGroup>
+                <OverflowMenuItem>Item 3</OverflowMenuItem>
+                <OverflowMenuItem>Item 4</OverflowMenuItem>
+                <OverflowMenuItem>Item 5</OverflowMenuItem>
+              </OverflowMenuGroup>
+            </OverflowMenuContent>
+            <OverflowMenuControl>
+              <Dropdown
+                onSelect={onSelect}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    aria-label="Height breakpoint on container example overflow menu"
+                    variant="plain"
+                    onClick={onToggle}
+                    isExpanded={isOpen}
+                    icon={<EllipsisVIcon />}
+                  />
+                )}
+                isOpen={isOpen}
+                onOpenChange={(isOpen) => setIsOpen(isOpen)}
+              >
+                <DropdownList>{dropdownItems}</DropdownList>
+              </Dropdown>
+            </OverflowMenuControl>
+          </OverflowMenu>
         </div>
-        <Slider
-          value={containerHeight}
-          onChange={onChange}
-          max={100}
-          min={20}
-          step={20}
-          showTicks
-          showBoundaries={false}
-          aria-labelledby="overflowMenu-hasBreakpointOnContainer-height-slider-label"
-        />
-      </div>
-      <div ref={containerRef} id="height-breakpoint-reference-container" style={containerStyles}>
-        <OverflowMenu breakpointReference={containerRef} breakpoint="sm" isVertical>
-          <OverflowMenuContent>
-            <OverflowMenuItem>Item 1</OverflowMenuItem>
-            <OverflowMenuItem>Item 2</OverflowMenuItem>
-            <OverflowMenuGroup>
-              <OverflowMenuItem>Item 3</OverflowMenuItem>
-              <OverflowMenuItem>Item 4</OverflowMenuItem>
-              <OverflowMenuItem>Item 5</OverflowMenuItem>
-            </OverflowMenuGroup>
-          </OverflowMenuContent>
-          <OverflowMenuControl>
-            <Dropdown
-              onSelect={onSelect}
-              toggle={(toggleRef) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  aria-label="Height breakpoint on container example overflow menu"
-                  variant="plain"
-                  onClick={onToggle}
-                  isExpanded={isOpen}
-                  icon={<EllipsisVIcon />}
-                />
-              )}
-              isOpen={isOpen}
-              onOpenChange={(isOpen) => setIsOpen(isOpen)}
-            >
-              <DropdownList>{dropdownItems}</DropdownList>
-            </Dropdown>
-          </OverflowMenuControl>
-        </OverflowMenu>
       </div>
     </>
   );

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimpleVertical.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimpleVertical.tsx
@@ -42,7 +42,7 @@ export const OverflowMenuSimpleVertical: React.FunctionComponent = () => {
   ];
 
   return (
-    <OverflowMenu breakpoint="lg" isVertical>
+    <OverflowMenu breakpoint="md" isVertical>
       <OverflowMenuContent>
         <OverflowMenuItem>Item</OverflowMenuItem>
         <OverflowMenuItem>Item</OverflowMenuItem>

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimpleVertical.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimpleVertical.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem,
+  MenuToggle,
+  Dropdown,
+  DropdownList
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+
+export const OverflowMenuSimpleVertical: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const dropdownItems = [
+    <OverflowMenuDropdownItem itemId={0} key="item1" isShared>
+      Item 1
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={1} key="item2" isShared>
+      Item 2
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={2} key="item3" isShared>
+      Item 3
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={3} key="item4" isShared>
+      Item 4
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem itemId={5} key="item5" isShared>
+      Item 5
+    </OverflowMenuDropdownItem>
+  ];
+
+  return (
+    <OverflowMenu breakpoint="lg" isVertical>
+      <OverflowMenuContent>
+        <OverflowMenuItem>Item</OverflowMenuItem>
+        <OverflowMenuItem>Item</OverflowMenuItem>
+        <OverflowMenuGroup>
+          <OverflowMenuItem>Item</OverflowMenuItem>
+          <OverflowMenuItem>Item</OverflowMenuItem>
+          <OverflowMenuItem>Item</OverflowMenuItem>
+        </OverflowMenuGroup>
+      </OverflowMenuContent>
+      <OverflowMenuControl>
+        <Dropdown
+          onSelect={onSelect}
+          toggle={(toggleRef) => (
+            <MenuToggle
+              ref={toggleRef}
+              aria-label="Simple example overflow menu"
+              variant="plain"
+              onClick={onToggle}
+              isExpanded={isOpen}
+              icon={<EllipsisVIcon />}
+            />
+          )}
+          isOpen={isOpen}
+          onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        >
+          <DropdownList>{dropdownItems}</DropdownList>
+        </Dropdown>
+      </OverflowMenuControl>
+    </OverflowMenu>
+  );
+};

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimpleVertical.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimpleVertical.tsx
@@ -36,7 +36,7 @@ export const OverflowMenuSimpleVertical: React.FunctionComponent = () => {
     <OverflowMenuDropdownItem itemId={3} key="item4" isShared>
       Item 4
     </OverflowMenuDropdownItem>,
-    <OverflowMenuDropdownItem itemId={5} key="item5" isShared>
+    <OverflowMenuDropdownItem itemId={4} key="item5" isShared>
       Item 5
     </OverflowMenuDropdownItem>
   ];

--- a/packages/react-core/src/components/Toolbar/ToolbarContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarContent.tsx
@@ -8,8 +8,16 @@ import { PageContext } from '../Page/PageContext';
 export interface ToolbarContentProps extends React.HTMLProps<HTMLDivElement> {
   /** Classes applied to root element of the data toolbar content row */
   className?: string;
-  /** Visibility at various breakpoints. */
+  /** Visibility at various width breakpoints. */
   visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Visibility at various height breakpoints. */
+  visibilityAtHeight?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
     lg?: 'hidden' | 'visible';
@@ -59,6 +67,7 @@ class ToolbarContent extends Component<ToolbarContentProps> {
       isExpanded,
       toolbarId,
       visibility,
+      visibilityAtHeight,
       rowWrap,
       alignItems,
       clearAllFilters,
@@ -69,11 +78,12 @@ class ToolbarContent extends Component<ToolbarContentProps> {
 
     return (
       <PageContext.Consumer>
-        {({ width, getBreakpoint }) => (
+        {({ width, getBreakpoint, height, getVerticalBreakpoint }) => (
           <div
             className={css(
               styles.toolbarContent,
               formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),
+              formatBreakpointMods(visibilityAtHeight, styles, '', getVerticalBreakpoint(height), true),
               className
             )}
             ref={this.expandableContentRef}

--- a/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
@@ -23,8 +23,16 @@ export interface ToolbarGroupProps extends Omit<React.HTMLProps<HTMLDivElement>,
     | 'action-group-inline'
     | 'action-group-plain'
     | 'label-group';
-  /** Visibility at various breakpoints. */
+  /** Visibility at various width breakpoints. */
   visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Visibility at various height breakpoints. */
+  visibilityAtHeight?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
     lg?: 'hidden' | 'visible';
@@ -178,6 +186,7 @@ class ToolbarGroupWithRef extends Component<ToolbarGroupProps> {
   render() {
     const {
       visibility,
+      visibilityAtHeight,
       align,
       alignItems,
       alignSelf,
@@ -195,7 +204,7 @@ class ToolbarGroupWithRef extends Component<ToolbarGroupProps> {
 
     return (
       <PageContext.Consumer>
-        {({ width, getBreakpoint }) => (
+        {({ width, getBreakpoint, height, getVerticalBreakpoint }) => (
           <div
             className={css(
               styles.toolbarGroup,
@@ -209,6 +218,7 @@ class ToolbarGroupWithRef extends Component<ToolbarGroupProps> {
                     | 'labelGroup'
                 ],
               formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),
+              formatBreakpointMods(visibilityAtHeight, styles, '', getVerticalBreakpoint(height), true),
               formatBreakpointMods(align, styles, '', getBreakpoint(width)),
               formatBreakpointMods(gap, styles, '', getBreakpoint(width)),
               formatBreakpointMods(columnGap, styles, '', getBreakpoint(width)),

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -17,8 +17,16 @@ export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** A type modifier which modifies spacing specifically depending on the type of item */
   variant?: ToolbarItemVariant | 'pagination' | 'label' | 'label-group' | 'separator' | 'expand-all';
-  /** Visibility at various breakpoints. */
+  /** Visibility at various width breakpoints. */
   visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Visibility at various height breakpoints. */
+  visibilityAtHeight?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
     lg?: 'hidden' | 'visible';
@@ -174,6 +182,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   className,
   variant,
   visibility,
+  visibilityAtHeight,
   gap,
   columnGap,
   rowGap,
@@ -202,7 +211,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
 
   return (
     <PageContext.Consumer>
-      {({ width, getBreakpoint }) => (
+      {({ width, getBreakpoint, height, getVerticalBreakpoint }) => (
         <div
           className={css(
             styles.toolbarItem,
@@ -211,6 +220,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
             isAllExpanded && styles.modifiers.expanded,
             isOverflowContainer && styles.modifiers.overflowContainer,
             formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),
+            formatBreakpointMods(visibilityAtHeight, styles, '', getVerticalBreakpoint(height), true),
             formatBreakpointMods(align, styles, '', getBreakpoint(width)),
             formatBreakpointMods(gap, styles, '', getBreakpoint(width)),
             formatBreakpointMods(columnGap, styles, '', getBreakpoint(width)),

--- a/packages/react-core/src/components/Toolbar/__tests__/Toolbar.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/Toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { createElement, Fragment } from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -206,6 +206,32 @@ describe('Toolbar', () => {
     });
   });
 
+  const bps = ['default', 'md', 'lg', 'xl', '2xl'] as const;
+  describe.each(bps)(`ToolbarContent visibilityAtHeight`, (bp) => {
+    it(`Applies correct visible class at ${bp}`, () => {
+      render(
+        <ToolbarContent data-testid="toolbarcontent" visibilityAtHeight={{ [bp]: 'visible' }}>
+          Test
+        </ToolbarContent>
+      );
+
+      if (bp !== 'default') {
+        expect(screen.getByTestId('toolbarcontent')).toHaveClass(`pf-m-visible-on-${bp}-height`);
+      }
+    });
+
+    it(`Applies correct hidden class at ${bp}`, () => {
+      render(
+        <ToolbarContent data-testid="toolbarcontent" visibilityAtHeight={{ [bp]: 'hidden' }}>
+          Test
+        </ToolbarContent>
+      );
+
+      const expectedClass = bp === 'default' ? 'pf-m-hidden' : `pf-m-hidden-on-${bp}-height`;
+      expect(screen.getByTestId('toolbarcontent')).toHaveClass(expectedClass);
+    });
+  });
+
   it(`Renders toolbar without ${styles.modifiers.vertical} by default`, () => {
     render(
       <Toolbar data-testid="Toolbar-test-is-not-vertical">
@@ -220,7 +246,7 @@ describe('Toolbar', () => {
     expect(screen.getByTestId('Toolbar-test-is-not-vertical')).not.toHaveClass(styles.modifiers.vertical);
   });
 
-  it('Renders with class ${styles.modifiers.vertical} when isVertical is true', () => {
+  it(`Renders with class ${styles.modifiers.vertical} when isVertical is true`, () => {
     const items = (
       <Fragment>
         <ToolbarItem>Test</ToolbarItem>

--- a/packages/react-core/src/components/Toolbar/__tests__/ToolbarGroup.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/ToolbarGroup.test.tsx
@@ -37,4 +37,30 @@ describe('ToolbarGroup', () => {
       });
     });
   });
+
+  const bps = ['default', 'md', 'lg', 'xl', '2xl'] as const;
+  describe.each(bps)(`ToolbarGroup visibilityAtHeight`, (bp) => {
+    it(`Applies correct visible class at ${bp}`, () => {
+      render(
+        <ToolbarGroup data-testid="toolbargroup" visibilityAtHeight={{ [bp]: 'visible' }}>
+          Test
+        </ToolbarGroup>
+      );
+
+      if (bp !== 'default') {
+        expect(screen.getByTestId('toolbargroup')).toHaveClass(`pf-m-visible-on-${bp}-height`);
+      }
+    });
+
+    it(`Applies correct hidden class at ${bp}`, () => {
+      render(
+        <ToolbarGroup data-testid="toolbargroup" visibilityAtHeight={{ [bp]: 'hidden' }}>
+          Test
+        </ToolbarGroup>
+      );
+
+      const expectedClass = bp === 'default' ? 'pf-m-hidden' : `pf-m-hidden-on-${bp}-height`;
+      expect(screen.getByTestId('toolbargroup')).toHaveClass(expectedClass);
+    });
+  });
 });

--- a/packages/react-core/src/components/Toolbar/__tests__/ToolbarItem.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/ToolbarItem.test.tsx
@@ -37,4 +37,30 @@ describe('ToolbarItem', () => {
       });
     });
   });
+
+  const bps = ['default', 'md', 'lg', 'xl', '2xl'] as const;
+  describe.each(bps)(`ToolbarItem visibilityAtHeight`, (bp) => {
+    it(`Applies correct visible class at ${bp}`, () => {
+      render(
+        <ToolbarItem data-testid="toolbaritem" visibilityAtHeight={{ [bp]: 'visible' }}>
+          Test
+        </ToolbarItem>
+      );
+
+      if (bp !== 'default') {
+        expect(screen.getByTestId('toolbaritem')).toHaveClass(`pf-m-visible-on-${bp}-height`);
+      }
+    });
+
+    it(`Applies correct hidden class at ${bp}`, () => {
+      render(
+        <ToolbarItem data-testid="toolbaritem" visibilityAtHeight={{ [bp]: 'hidden' }}>
+          Test
+        </ToolbarItem>
+      );
+
+      const expectedClass = bp === 'default' ? 'pf-m-hidden' : `pf-m-hidden-on-${bp}-height`;
+      expect(screen.getByTestId('toolbaritem')).toHaveClass(expectedClass);
+    });
+  });
 });

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -34,6 +34,14 @@ To adjust a toolbar’s inset, use the `inset` property. You can set the inset v
 
 ```
 
+### Vertical toolbar
+
+A toolbar's orientation may be changed using the `isVertical` property. Responsive behavior when height is adjusted may be customized for the `ToolbarContent`, `ToolbarGroup`, and `ToolbarItem` components using their respective `visibilityAtHeight` property.
+
+```ts file="./ToolbarVertical.tsx"
+
+```
+
 ### Sticky toolbar
 
 To lock a toolbar and prevent it from scrolling with other content, use a sticky toolbar.
@@ -114,11 +122,13 @@ When all of a toolbar's required elements cannot fit in a single line, you can s
 ```
 
 ## Examples with spacers and wrapping
+
 You may adjust the space between toolbar items to arrange them into groups. Read our spacers documentation to learn more about using spacers.
 
 Items are spaced “16px” apart by default and can be modified by changing their or their parents' `gap`, `columnGap`, and `rowGap` properties. You can set the property values at multiple breakpoints, including "default", "md", "lg", "xl", and "2xl".
 
 ### Toolbar content wrapping
+
 The toolbar content section will wrap by default, but you can set the `rowRap` property to `noWrap` to make it not wrap.
 
 ```ts file="./ToolbarContentWrap.tsx"

--- a/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
+++ b/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
@@ -1,0 +1,33 @@
+import { Button, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
+import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
+import SyncIcon from '@patternfly/react-icons/dist/esm/icons/sync-icon';
+
+export const ToolbarGroups: React.FunctionComponent = () => (
+  <Toolbar id="toolbar-vertical" isVertical>
+    <ToolbarContent>
+      <ToolbarGroup variant="action-group-plain">
+        <ToolbarItem>
+          <Button variant="plain" aria-label="edit" icon={<EditIcon />} />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button variant="plain" aria-label="clone" icon={<CloneIcon />} />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button variant="plain" aria-label="sync" icon={<SyncIcon />} />
+        </ToolbarItem>
+      </ToolbarGroup>
+      <ToolbarGroup variant="action-group-plain" visibility={{ default: 'hidden', md: 'visible' }}>
+        <ToolbarItem>
+          <Button variant="plain" aria-label="edit" icon={<EditIcon />} />
+        </ToolbarItem>
+        <ToolbarItem visibility={{ default: 'hidden', lg: 'visible' }}>
+          <Button variant="plain" aria-label="clone" icon={<CloneIcon />} />
+        </ToolbarItem>
+        <ToolbarItem visibility={{ default: 'hidden', lg: 'visible' }}>
+          <Button variant="plain" aria-label="sync" icon={<SyncIcon />} />
+        </ToolbarItem>
+      </ToolbarGroup>
+    </ToolbarContent>
+  </Toolbar>
+);

--- a/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
+++ b/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
@@ -14,7 +14,7 @@ export const ToolbarVertical: React.FunctionComponent = () => (
           Item 5 (visible above lg breakpoint)
         </ToolbarItem>
         <ToolbarItem visibilityAtHeight={{ default: 'hidden', lg: 'visible' }}>
-          Item 6 (visible above md breakpoint)
+          Item 6 (visible above lg breakpoint)
         </ToolbarItem>
       </ToolbarGroup>
     </ToolbarContent>

--- a/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
+++ b/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
@@ -1,31 +1,20 @@
-import { Button, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
-import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
-import SyncIcon from '@patternfly/react-icons/dist/esm/icons/sync-icon';
+import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 
-export const ToolbarGroups: React.FunctionComponent = () => (
+export const ToolbarVertical: React.FunctionComponent = () => (
   <Toolbar id="toolbar-vertical" isVertical>
     <ToolbarContent>
       <ToolbarGroup variant="action-group-plain">
-        <ToolbarItem>
-          <Button variant="plain" aria-label="edit" icon={<EditIcon />} />
-        </ToolbarItem>
-        <ToolbarItem>
-          <Button variant="plain" aria-label="clone" icon={<CloneIcon />} />
-        </ToolbarItem>
-        <ToolbarItem>
-          <Button variant="plain" aria-label="sync" icon={<SyncIcon />} />
-        </ToolbarItem>
+        <ToolbarItem>Item 1</ToolbarItem>
+        <ToolbarItem>Item 2</ToolbarItem>
+        <ToolbarItem>Item 3</ToolbarItem>
       </ToolbarGroup>
       <ToolbarGroup variant="action-group-plain" visibilityAtHeight={{ default: 'hidden', md: 'visible' }}>
-        <ToolbarItem>
-          <Button variant="plain" aria-label="edit" icon={<EditIcon />} />
+        <ToolbarItem>Item 4 (visible above md breakpoint)</ToolbarItem>
+        <ToolbarItem visibilityAtHeight={{ default: 'hidden', lg: 'visible' }}>
+          Item 5 (visible above lg breakpoint)
         </ToolbarItem>
         <ToolbarItem visibilityAtHeight={{ default: 'hidden', lg: 'visible' }}>
-          <Button variant="plain" aria-label="clone" icon={<CloneIcon />} />
-        </ToolbarItem>
-        <ToolbarItem visibilityAtHeight={{ default: 'hidden', lg: 'visible' }}>
-          <Button variant="plain" aria-label="sync" icon={<SyncIcon />} />
+          Item 6 (visible above md breakpoint)
         </ToolbarItem>
       </ToolbarGroup>
     </ToolbarContent>

--- a/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
+++ b/packages/react-core/src/components/Toolbar/examples/ToolbarVertical.tsx
@@ -17,14 +17,14 @@ export const ToolbarGroups: React.FunctionComponent = () => (
           <Button variant="plain" aria-label="sync" icon={<SyncIcon />} />
         </ToolbarItem>
       </ToolbarGroup>
-      <ToolbarGroup variant="action-group-plain" visibility={{ default: 'hidden', md: 'visible' }}>
+      <ToolbarGroup variant="action-group-plain" visibilityAtHeight={{ default: 'hidden', md: 'visible' }}>
         <ToolbarItem>
           <Button variant="plain" aria-label="edit" icon={<EditIcon />} />
         </ToolbarItem>
-        <ToolbarItem visibility={{ default: 'hidden', lg: 'visible' }}>
+        <ToolbarItem visibilityAtHeight={{ default: 'hidden', lg: 'visible' }}>
           <Button variant="plain" aria-label="clone" icon={<CloneIcon />} />
         </ToolbarItem>
-        <ToolbarItem visibility={{ default: 'hidden', lg: 'visible' }}>
+        <ToolbarItem visibilityAtHeight={{ default: 'hidden', lg: 'visible' }}>
           <Button variant="plain" aria-label="sync" icon={<SyncIcon />} />
         </ToolbarItem>
       </ToolbarGroup>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12335

Needs https://github.com/patternfly/patternfly/pull/8295 to be pulled in when merged for styling

- Adds `visibilityAtHeight` props to `ToolbarItem`, `ToolbarGroup`, `ToolbarContent` that allows visibility to be changed based on specific height breakpoints
- Adds `isVertical` to `OverflowMenu` that changes the layout orientation for vertical toolbars/elements that use OverflowMenu
- Adds examples for Toolbar and OverflowMenu

Some notes:
I changed the OverflowMenu container example to full page to allow enough height for the breakpoint to change.
I also added a warning for vertical OverflowMenus that the `sm` breakpoint won't do anything (it evaluates to 0 from the token and cannot be calc'd - in practice `sm` means that something is always visible/above the breakpoint for OverflowMenu). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vertical orientation support to OverflowMenu with height-based responsive behavior.
  * Added height-responsive visibility controls to Toolbar components (ToolbarContent, ToolbarGroup, ToolbarItem) for responsive show/hide behavior based on container height.
  * Introduced vertical Toolbar layout option with automatic height-based responsiveness.

* **Documentation**
  * Added examples and guides for vertical OverflowMenu and Toolbar layouts.
  * Clarified width vs. height-based breakpoint behavior in component documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->