### PR TITLE
chore(PlusCircleIcon): Replace all usages of PlusCircleIcon with RhUAddCircleFillIcon

### DIFF
--- a/packages/react-core/src/components/Button/examples/Button.md
+++ b/packages/react-core/src/components/Button/examples/Button.md
@@ -8,8 +8,8 @@ ouia: true
 
 import { Fragment, useState } from 'react';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import RhUiExternalLinkFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-fill-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-icon';
 import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';

--- a/packages/react-core/src/components/Button/examples/ButtonAriaDisabled.tsx
+++ b/packages/react-core/src/components/Button/examples/ButtonAriaDisabled.tsx
@@ -1,11 +1,11 @@
 import { Button, Flex, Tooltip } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const ButtonAriaDisabled: React.FunctionComponent = () => (
   <>
     <Flex columnGap={{ default: 'columnGapSm' }}>
       <Button isAriaDisabled>Primary aria disabled</Button>
-      <Button isAriaDisabled variant="link" icon={<PlusCircleIcon />}>
+      <Button isAriaDisabled variant="link" icon={<RhUiAddCircleFillIcon />}>
         Link aria disabled
       </Button>
       <Button isAriaDisabled variant="link" isInline>

--- a/packages/react-core/src/components/Button/examples/ButtonCircle.tsx
+++ b/packages/react-core/src/components/Button/examples/ButtonCircle.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex } from '@patternfly/react-core';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';
@@ -22,17 +22,32 @@ export const ButtonCircle: React.FunctionComponent = () => {
 
   return (
     <Flex columnGap={{ default: 'columnGapSm' }}>
-      <Button isCircle icon={<PlusCircleIcon />} aria-label="Add primary circle variant example" />
+      <Button isCircle icon={<RhUiAddCircleFillIcon />} aria-label="Add primary circle variant example" />
       <Button
         variant="secondary"
         isCircle
-        icon={<PlusCircleIcon />}
+        icon={<RhUiAddCircleFillIcon />}
         aria-label="Add secondary circle variant example"
       />
-      <Button variant="tertiary" isCircle icon={<PlusCircleIcon />} aria-label="Add tertiary circle variant example" />
-      <Button variant="danger" isCircle icon={<PlusCircleIcon />} aria-label="Add danger circle variant example" />
-      <Button variant="warning" isCircle icon={<PlusCircleIcon />} aria-label="Add warning circle variant example" />
-      <Button variant="link" isCircle icon={<PlusCircleIcon />} aria-label="Add link circle variant example" />
+      <Button
+        variant="tertiary"
+        isCircle
+        icon={<RhUiAddCircleFillIcon />}
+        aria-label="Add tertiary circle variant example"
+      />
+      <Button
+        variant="danger"
+        isCircle
+        icon={<RhUiAddCircleFillIcon />}
+        aria-label="Add danger circle variant example"
+      />
+      <Button
+        variant="warning"
+        isCircle
+        icon={<RhUiAddCircleFillIcon />}
+        aria-label="Add warning circle variant example"
+      />
+      <Button variant="link" isCircle icon={<RhUiAddCircleFillIcon />} aria-label="Add link circle variant example" />
       <Button variant="control" isCircle icon={<CopyIcon />} aria-label="Copy control circle variant example" />
       <Button variant="plain" isCircle icon={<RhMicronsCloseIcon />} aria-label="Remove plain circle variant example" />
       <Button

--- a/packages/react-core/src/components/Button/examples/ButtonDisabled.tsx
+++ b/packages/react-core/src/components/Button/examples/ButtonDisabled.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex } from '@patternfly/react-core';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 
 export const ButtonDisabled: React.FunctionComponent = () => (
@@ -25,7 +25,7 @@ export const ButtonDisabled: React.FunctionComponent = () => (
     </Flex>
     <br />
     <Flex columnGap={{ default: 'columnGapSm' }}>
-      <Button isDisabled variant="link" icon={<PlusCircleIcon />}>
+      <Button isDisabled variant="link" icon={<RhUiAddCircleFillIcon />}>
         Link
       </Button>
       <Button isDisabled variant="link" isInline>

--- a/packages/react-core/src/components/Button/examples/ButtonVariations.tsx
+++ b/packages/react-core/src/components/Button/examples/ButtonVariations.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex } from '@patternfly/react-core';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import RhUiExternalLinkFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-fill-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 
@@ -29,7 +29,7 @@ export const ButtonVariations: React.FunctionComponent = () => (
     </Flex>
     <br />
     <Flex columnGap={{ default: 'columnGapSm' }}>
-      <Button variant="link" icon={<PlusCircleIcon />}>
+      <Button variant="link" icon={<RhUiAddCircleFillIcon />}>
         Link
       </Button>
       <Button variant="link" icon={<RhUiExternalLinkFillIcon />} iconPosition="end">

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
@@ -17,7 +17,7 @@ propComponents:
 
 import { useState } from 'react';
 import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, DescriptionListTermHelpText, DescriptionListTermHelpTextButton, Popover, Checkbox, Card } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import BookIcon from '@patternfly/react-icons/dist/esm/icons/book-icon';
 import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListAutoFitBasic.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListAutoFitBasic.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListAutoFitBasic: React.FunctionComponent = () => (
   <DescriptionList isAutoFit aria-label="Basic auto-fit">
@@ -26,7 +26,7 @@ export const DescriptionListAutoFitBasic: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListAutoFitMinWidthModified.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListAutoFitMinWidthModified.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListAutoFitMinWidthModified: React.FunctionComponent = () => (
   <DescriptionList
@@ -30,7 +30,7 @@ export const DescriptionListAutoFitMinWidthModified: React.FunctionComponent = (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListAutoFitMinWidthResponsive.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListAutoFitMinWidthResponsive.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListAutoFitMinWidthResponsive: React.FunctionComponent = () => (
   <DescriptionList
@@ -30,7 +30,7 @@ export const DescriptionListAutoFitMinWidthResponsive: React.FunctionComponent =
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListBasic.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListBasic.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListBasic: React.FunctionComponent = () => (
   <DescriptionList aria-label="Basic example">
@@ -26,7 +26,7 @@ export const DescriptionListBasic: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListColumnFill.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListColumnFill.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListColumnFill: React.FunctionComponent = () => (
   <DescriptionList isFillColumns columnModifier={{ default: '2Col', lg: '3Col' }} aria-label="Column fill enabled">
@@ -28,7 +28,7 @@ export const DescriptionListColumnFill: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListCompact.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListCompact.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListCompact: React.FunctionComponent = () => (
   <DescriptionList isCompact aria-label="Compact example">
@@ -26,7 +26,7 @@ export const DescriptionListCompact: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListCompactHorizontal.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListCompactHorizontal.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListCompactHorizontal: React.FunctionComponent = () => (
   <DescriptionList isCompact isHorizontal aria-label="Compact horizontal">
@@ -26,7 +26,7 @@ export const DescriptionListCompactHorizontal: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultAutoColumn.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultAutoColumn.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDefaultAutoColumn: React.FunctionComponent = () => (
   <DescriptionList isAutoColumnWidths columnModifier={{ default: '3Col' }} aria-label="Default auto column width">
@@ -26,7 +26,7 @@ export const DescriptionListDefaultAutoColumn: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultInlineGrid.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultInlineGrid.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDefaultInlineGrid: React.FunctionComponent = () => (
   <DescriptionList columnModifier={{ default: '3Col' }} isInlineGrid aria-label="Default inline grid">
@@ -26,7 +26,7 @@ export const DescriptionListDefaultInlineGrid: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultResponsiveColumns.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultResponsiveColumns.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDefaultResponsiveColumns: React.FunctionComponent = () => (
   <DescriptionList columnModifier={{ lg: '2Col', xl: '3Col' }} aria-label="Default responsive columns">
@@ -26,7 +26,7 @@ export const DescriptionListDefaultResponsiveColumns: React.FunctionComponent = 
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultThreeColLg.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultThreeColLg.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDefaultThreeColLg: React.FunctionComponent = () => (
   <DescriptionList columnModifier={{ lg: '3Col' }} aria-label="Three-column on large screens">
@@ -26,7 +26,7 @@ export const DescriptionListDefaultThreeColLg: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultTwoCol.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDefaultTwoCol.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDefaultTwoCol: React.FunctionComponent = () => (
   <DescriptionList
@@ -31,7 +31,7 @@ export const DescriptionListDefaultTwoCol: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDisplaySizeAndCardHorizontalTermWidth.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDisplaySizeAndCardHorizontalTermWidth.tsx
@@ -1,5 +1,5 @@
 import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, Card } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDisplaySizeAndCardHorizontalTermWidth: React.FunctionComponent = () => (
   <DescriptionList
@@ -26,7 +26,7 @@ export const DescriptionListDisplaySizeAndCardHorizontalTermWidth: React.Functio
     <Card component="div">
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListDisplaySizeAndCardThreeColumn.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListDisplaySizeAndCardThreeColumn.tsx
@@ -1,5 +1,5 @@
 import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, Card } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListDisplayLgAndCardThreeColumn: React.FunctionComponent = () => (
   <DescriptionList
@@ -24,7 +24,7 @@ export const DescriptionListDisplayLgAndCardThreeColumn: React.FunctionComponent
     <Card component="div">
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListFluidHorizontal.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListFluidHorizontal.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListFluidHorizontal: React.FunctionComponent = () => (
   <DescriptionList isHorizontal isFluid aria-label="Fluid horizontal">
@@ -26,7 +26,7 @@ export const DescriptionListFluidHorizontal: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontal.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontal.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListHorizontal: React.FunctionComponent = () => (
   <DescriptionList isHorizontal aria-label="Horizontal">
@@ -26,7 +26,7 @@ export const DescriptionListHorizontal: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalAutoColumn.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalAutoColumn.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListHorizontalAutoColumn: React.FunctionComponent = () => (
   <DescriptionList
@@ -31,7 +31,7 @@ export const DescriptionListHorizontalAutoColumn: React.FunctionComponent = () =
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalCustomTermWidth.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalCustomTermWidth.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListHorizontalCustomTermWidth: React.FunctionComponent = () => (
   <DescriptionList
@@ -37,7 +37,7 @@ export const DescriptionListHorizontalCustomTermWidth: React.FunctionComponent =
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalResponsiveColumns.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalResponsiveColumns.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListHorizontalResponsiveColumns: React.FunctionComponent = () => (
   <DescriptionList isHorizontal columnModifier={{ lg: '2Col', xl: '3Col' }} aria-label="Horizontal responsive columns">
@@ -26,7 +26,7 @@ export const DescriptionListHorizontalResponsiveColumns: React.FunctionComponent
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalThreeColLg.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalThreeColLg.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListHorizontalThreeColLg: React.FunctionComponent = () => (
   <DescriptionList isHorizontal columnModifier={{ lg: '3Col' }} aria-label="Three-columns horizontal on large screens">
@@ -26,7 +26,7 @@ export const DescriptionListHorizontalThreeColLg: React.FunctionComponent = () =
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalTwoCol.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListHorizontalTwoCol.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListHorizontalTwoCol: React.FunctionComponent = () => (
   <DescriptionList isHorizontal columnModifier={{ default: '2Col' }} aria-label="Two-column horizontal">
@@ -26,7 +26,7 @@ export const DescriptionListHorizontalTwoCol: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListIconsOnTerms.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListIconsOnTerms.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import BookIcon from '@patternfly/react-icons/dist/esm/icons/book-icon';
 import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';
@@ -31,7 +31,7 @@ export const DescriptionListIconsOnTerms: React.FunctionComponent = () => (
     <DescriptionListGroup>
       <DescriptionListTerm icon={<GlobeIcon />}>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListResponsiveHoriVertGroup.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListResponsiveHoriVertGroup.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListDescription
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListResponsiveHoriVertGroup: React.FunctionComponent = () => (
   <DescriptionList
@@ -35,7 +35,7 @@ export const DescriptionListResponsiveHoriVertGroup: React.FunctionComponent = (
     <DescriptionListGroup>
       <DescriptionListTerm>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithCard.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithCard.tsx
@@ -7,7 +7,7 @@ import {
   Card,
   Checkbox
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListWithCard: React.FunctionComponent = () => {
   const [isChecked, setIsChecked] = useState<boolean>(false);
@@ -47,7 +47,7 @@ export const DescriptionListWithCard: React.FunctionComponent = () => {
         <Card component="div" isSelectable={isSelectable}>
           <DescriptionListTerm>Pod selector</DescriptionListTerm>
           <DescriptionListDescription>
-            <Button variant="link" isInline icon={<PlusCircleIcon />}>
+            <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
               app=MyApp
             </Button>
           </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithLargeDisplaySize.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithLargeDisplaySize.tsx
@@ -7,7 +7,7 @@ import {
   DescriptionListDescription,
   Checkbox
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListWithLargeDisplaySize: React.FunctionComponent = () => {
   const [isChecked, setIsChecked] = useState<boolean>(false);
@@ -48,7 +48,7 @@ export const DescriptionListWithLargeDisplaySize: React.FunctionComponent = () =
         <DescriptionListGroup>
           <DescriptionListTerm>Pod selector</DescriptionListTerm>
           <DescriptionListDescription>
-            <Button variant="link" isInline icon={<PlusCircleIcon />}>
+            <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
               app=MyApp
             </Button>
           </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithLargeDisplaySizeAndCard.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithLargeDisplaySizeAndCard.tsx
@@ -7,7 +7,7 @@ import {
   Card,
   Checkbox
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListWithLargeDisplaySizeAndCard: React.FunctionComponent = () => {
   const [isChecked, setIsChecked] = useState<boolean>(false);
@@ -52,7 +52,7 @@ export const DescriptionListWithLargeDisplaySizeAndCard: React.FunctionComponent
         <Card component="div">
           <DescriptionListTerm>Pod selector</DescriptionListTerm>
           <DescriptionListDescription>
-            <Button variant="link" isInline icon={<PlusCircleIcon />}>
+            <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
               app=MyApp
             </Button>
           </DescriptionListDescription>

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithTermHelpText.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListWithTermHelpText.tsx
@@ -7,7 +7,7 @@ import {
   DescriptionListTermHelpTextButton,
   Popover
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListWithTermHelpText: React.FunctionComponent = () => (
   <DescriptionList aria-label="Term help text">
@@ -44,7 +44,7 @@ export const DescriptionListWithTermHelpText: React.FunctionComponent = () => (
         </Popover>
       </DescriptionListTermHelpText>
       <DescriptionListDescription>
-        <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp
         </Button>
       </DescriptionListDescription>

--- a/packages/react-core/src/components/Icon/examples/BodyIconSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/BodyIconSizes.tsx
@@ -1,17 +1,17 @@
 import { Fragment } from 'react';
 import { Icon } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const BodyIconSizes: React.FunctionComponent = () => (
   <Fragment>
     <Icon size="bodySm">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="bodyDefault">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="bodyLg">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>
   </Fragment>
 );

--- a/packages/react-core/src/components/Icon/examples/HeadingIconSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/HeadingIconSizes.tsx
@@ -1,26 +1,26 @@
 import { Fragment } from 'react';
 import { Icon } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const HeadingIconSizes: React.FunctionComponent = () => (
   <Fragment>
     <Icon size="headingSm">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="headingMd">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="headingLg">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="headingXl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="heading_2xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="heading_3xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>
   </Fragment>
 );

--- a/packages/react-core/src/components/Icon/examples/Icon.md
+++ b/packages/react-core/src/components/Icon/examples/Icon.md
@@ -10,7 +10,7 @@ import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-ar
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import RhUiErrorFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-error-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';

--- a/packages/react-core/src/components/Icon/examples/IconContentSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/IconContentSizes.tsx
@@ -1,20 +1,20 @@
 import { Fragment } from 'react';
 import { Icon } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const IconContentSizes: React.FunctionComponent = () => (
   <Fragment>
     <Icon size="3xl" iconSize="lg">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="3xl" iconSize="xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="3xl" iconSize="2xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="3xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>
   </Fragment>
 );

--- a/packages/react-core/src/components/Icon/examples/IconInline.tsx
+++ b/packages/react-core/src/components/Icon/examples/IconInline.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { Icon, Content } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const IconInline: React.FunctionComponent = () => (
   <Fragment>
@@ -8,25 +8,25 @@ export const IconInline: React.FunctionComponent = () => (
       <h1>
         Heading
         <Icon isInline>
-          <PlusCircleIcon />
+          <RhUiAddCircleFillIcon />
         </Icon>
       </h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit Sed hendrerit nisi in cursus maximus.</p>
       <h2>
         Second level
         <Icon isInline>
-          <PlusCircleIcon />
+          <RhUiAddCircleFillIcon />
         </Icon>
       </h2>
       <p>
         <Icon isInline>
-          <PlusCircleIcon />
+          <RhUiAddCircleFillIcon />
         </Icon>
         Curabitur accumsan turpis pharetra
         <strong>
           augue tincidunt
           <Icon isInline>
-            <PlusCircleIcon />
+            <RhUiAddCircleFillIcon />
           </Icon>
         </strong>
         blandit. Quisque condimentum maximus mi, sit amet commodo arcu rutrum id. Proin pretium urna vel cursus
@@ -35,24 +35,24 @@ export const IconInline: React.FunctionComponent = () => (
       <small>
         Sometimes you need small text
         <Icon isInline>
-          <PlusCircleIcon />
+          <RhUiAddCircleFillIcon />
         </Icon>
       </small>
       Inline with size specified:
       <Icon size="sm" isInline>
-        <PlusCircleIcon />
+        <RhUiAddCircleFillIcon />
       </Icon>
       small,
       <Icon size="md" isInline>
-        <PlusCircleIcon />
+        <RhUiAddCircleFillIcon />
       </Icon>
       medium,
       <Icon size="lg" isInline>
-        <PlusCircleIcon />
+        <RhUiAddCircleFillIcon />
       </Icon>
       large,
       <Icon size="xl" isInline>
-        <PlusCircleIcon />
+        <RhUiAddCircleFillIcon />
       </Icon>
       extra large
     </Content>

--- a/packages/react-core/src/components/Icon/examples/StandaloneIconSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/StandaloneIconSizes.tsx
@@ -1,26 +1,26 @@
 import { Fragment } from 'react';
 import { Icon } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const StandaloneIconSizes: React.FunctionComponent = () => (
   <Fragment>
     <Icon size="sm">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="md">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="lg">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="2xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>{' '}
     <Icon size="3xl">
-      <PlusCircleIcon />
+      <RhUiAddCircleFillIcon />
     </Icon>
   </Fragment>
 );

--- a/packages/react-core/src/demos/CardView/CardView.md
+++ b/packages/react-core/src/demos/CardView/CardView.md
@@ -5,7 +5,7 @@ section: patterns
 
 import { Fragment, useState } from 'react';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import pfIcon from '../assets/pf-logo-small.svg';
 import activeMQIcon from '../assets/activemq-core_200x150.png';
 import avroIcon from '../assets/camel-avro_200x150.png';

--- a/packages/react-core/src/demos/CardView/examples/CardView.tsx
+++ b/packages/react-core/src/demos/CardView/examples/CardView.tsx
@@ -35,7 +35,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import pfIcon from './assets/pf-logo-small.svg';
 import activeMQIcon from './assets/activemq-core_200x150.png';
 import avroIcon from './assets/camel-avro_200x150.png';
@@ -481,7 +481,7 @@ export const CardViewBasic: React.FunctionComponent = () => {
                 <EmptyState
                   headingLevel="h2"
                   titleText="Add a new card to your page"
-                  icon={PlusCircleIcon}
+                  icon={RhUiAddCircleFillIcon}
                   variant={EmptyStateVariant.xs}
                 >
                   <EmptyStateFooter>

--- a/packages/react-core/src/demos/DescriptionList/DescriptionList.md
+++ b/packages/react-core/src/demos/DescriptionList/DescriptionList.md
@@ -5,7 +5,7 @@ section: components
 
 import { useRef, useState } from 'react';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 ## Demos

--- a/packages/react-core/src/demos/DescriptionList/examples/DescriptionListInDrawer.tsx
+++ b/packages/react-core/src/demos/DescriptionList/examples/DescriptionListInDrawer.tsx
@@ -18,7 +18,7 @@ import {
   Title
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 
 export const DescriptionListInDrawer: React.FunctionComponent = () => {
   const drawerRef = useRef<HTMLDivElement>(null);
@@ -89,7 +89,7 @@ export const DescriptionListInDrawer: React.FunctionComponent = () => {
           <DescriptionListGroup>
             <DescriptionListTerm>Pod selector</DescriptionListTerm>
             <DescriptionListDescription>
-              <Button variant="link" isInline icon={<PlusCircleIcon />}>
+              <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                 app=MyApp
               </Button>
             </DescriptionListDescription>

--- a/packages/react-icons/scripts/icons/pfToRhIcons.mjs
+++ b/packages/react-icons/scripts/icons/pfToRhIcons.mjs
@@ -115,6 +115,7 @@ export const pfToRhIcons = {
   PficonTemplateIcon: { name: 'rh-ui-template', icon: getIconData('rh-ui-template') },
   PficonVcenterIcon: { name: 'rh-ui-virtual-machine-center', icon: getIconData('rh-ui-virtual-machine-center') },
   PlayIcon: { name: 'rh-ui-play', icon: getIconData('rh-ui-play') },
+  PlusCircleIcon: { name: 'rh-ui-add-circle-fill', icon: getIconData('rh-ui-add-circle-fill') },
   PlusIcon: { name: 'rh-ui-add', icon: getIconData('rh-ui-add') },
   PortIcon: { name: 'rh-ui-port', icon: getIconData('rh-ui-port') },
   PowerOffIcon: { name: 'rh-ui-power', icon: getIconData('rh-ui-power') },

--- a/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import { Button, ButtonProps, ButtonSize, Tooltip } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 import { Link } from 'react-router-dom';
@@ -31,7 +31,7 @@ export class ButtonDemo extends Component<ButtonProps, ButtonDemoState> {
   linkButton: ButtonProps = {
     className: spacing.mSm,
     component: 'button',
-    icon: <PlusCircleIcon />,
+    icon: <RhUiAddCircleFillIcon />,
     onKeyPress: () => {
       window.location.href = 'https://github.com/patternfly/patternfly-react';
     },

--- a/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListBreakpointsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListBreakpointsDemo.tsx
@@ -9,7 +9,7 @@ import {
   Title,
   Divider
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import { Component } from 'react';
 
 export class DescriptionListBreakpointsDemo extends Component {
@@ -49,7 +49,7 @@ export class DescriptionListBreakpointsDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -96,7 +96,7 @@ export class DescriptionListBreakpointsDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -143,7 +143,7 @@ export class DescriptionListBreakpointsDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -196,7 +196,7 @@ export class DescriptionListBreakpointsDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>

--- a/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListDemo.tsx
@@ -12,7 +12,7 @@ import {
   Divider,
   Popover
 } from '@patternfly/react-core';
-import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
 import { Component } from 'react';
 
 export class DescriptionListDemo extends Component {
@@ -47,7 +47,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -105,7 +105,7 @@ export class DescriptionListDemo extends Component {
                 </Popover>
               </DescriptionListTermHelpText>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -152,7 +152,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -199,7 +199,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -242,7 +242,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -286,7 +286,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -329,7 +329,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -376,7 +376,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -417,7 +417,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>
@@ -458,7 +458,7 @@ export class DescriptionListDemo extends Component {
             <DescriptionListGroup>
               <DescriptionListTerm>Pod selector</DescriptionListTerm>
               <DescriptionListDescription>
-                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
                   app=MyApp
                 </Button>
               </DescriptionListDescription>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: towards #12244 

## Summary

- Map **PlusCircleIcon** to **rh-ui-add-circle-fill** in `packages/react-icons/scripts/icons/pfToRhIcons.mjs` for PF → RH icon resolution.
- Replace **PlusCircleIcon** with **RhUiAddCircleFillIcon** in examples, demos, docs, and Code Connect, importing from `@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the add/plus icon with a refreshed add-circle design across Buttons, Description Lists, Icon examples, CardView, and demo pages to ensure consistent visual appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #12396