### PR TITLE
chore(Star Icons): Replace all star FA icons with RH brand star icons

### DIFF
--- a/packages/react-core/src/components/Button/Button.tsx
+++ b/packages/react-core/src/components/Button/Button.tsx
@@ -4,8 +4,8 @@ import { css } from '@patternfly/react-styles';
 import { Spinner, spinnerSize } from '../Spinner';
 import { useOUIAProps, OUIAProps } from '../../helpers/OUIA/ouia';
 import { Badge } from '../Badge';
-import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
-import OutlinedStarIcon from '@patternfly/react-icons/dist/esm/icons/outlined-star-icon';
+import RhUiStarFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-star-fill-icon';
+import RhUiStarIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-star-icon';
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import { hamburgerIcon } from './hamburgerIcon';
 
@@ -211,10 +211,10 @@ const ButtonBase: React.FunctionComponent<ButtonProps> = ({
       iconContent = (
         <>
           <span className={css('pf-v6-c-button__icon-favorite')}>
-            <OutlinedStarIcon />
+            <RhUiStarIcon />
           </span>
           <span className={css('pf-v6-c-button__icon-favorited')}>
-            <StarIcon />
+            <RhUiStarFillIcon />
           </span>
         </>
       );

--- a/packages/react-icons/scripts/icons/pfToRhIcons.mjs
+++ b/packages/react-icons/scripts/icons/pfToRhIcons.mjs
@@ -104,6 +104,7 @@ export const pfToRhIcons = {
   OutlinedCommentsIcon: { name: 'rh-ui-comments', icon: getIconData('rh-ui-comments') },
   OutlinedHddIcon: { name: 'rh-ui-hard-drive', icon: getIconData('rh-ui-hard-drive') },
   OutlinedQuestionCircleIcon: { name: 'rh-ui-question-mark-circle', icon: getIconData('rh-ui-question-mark-circle') },
+  OutlinedStarIcon: { name: 'rh-ui-star', icon: getIconData('rh-ui-star') },
   OutlinedWindowRestoreIcon: { name: 'rh-ui-restore-window', icon: getIconData('rh-ui-restore-window') },
   PackageIcon: { name: 'rh-ui-package', icon: getIconData('rh-ui-package') },
   PauseCircleIcon: { name: 'rh-ui-pause-circle', icon: getIconData('rh-ui-pause-circle') },
@@ -151,7 +152,7 @@ export const pfToRhIcons = {
     icon: getIconData('rh-ui-sort-down-small-to-large')
   },
   SortAmountDownIcon: { name: 'rh-ui-sort-down-large-to-small', icon: getIconData('rh-ui-sort-down-large-to-small') },
-  StarIcon: { name: 'rh-ui-star', icon: getIconData('rh-ui-star') },
+  StarIcon: { name: 'rh-ui-star-fill', icon: getIconData('rh-ui-star-fill') },
   StorageDomainIcon: { name: 'rh-ui-storage-domain', icon: getIconData('rh-ui-storage-domain') },
   SyncAltIcon: { name: 'rh-ui-sync', icon: getIconData('rh-ui-sync') },
   TableIcon: { name: 'rh-ui-table', icon: getIconData('rh-ui-table') },

--- a/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -2,10 +2,10 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { IExtra, IFormatterValueType, ITransform } from '../../TableTypes';
 import { SortColumn, SortByDirection } from '../../SortColumn';
-import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
+import RhUiStarFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-star-fill-icon';
 
 export const sortableFavorites = (sort: any) => () =>
-  sortable(<StarIcon />, {
+  sortable(<RhUiStarFillIcon />, {
     columnIndex: sort.columnIndex,
     className: styles.tableFavorite,
     ariaLabel: sort.ariaLabel ?? 'Sort favorites',


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: towards #12244

## Summary

Replaces PatternFly `star-icon` / `outlined-star-icon` usage with Red Hat UI star icons where favorites and sortable-favorites rely on those components.

## What changed

- **`packages/react-core/src/components/Button/Button.tsx`**
  - Favorite button (not favorited): `OutlinedStarIcon` → `RhUiStarIcon` (`rh-ui-star-icon`)
  - Favorite button (favorited): `StarIcon` → `RhUiStarFillIcon` (`rh-ui-star-fill-icon`)

- **`packages/react-table/src/components/Table/utils/decorators/sortable.tsx`**
  - `sortableFavorites` column label: `StarIcon` → `RhUiStarFillIcon`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style Updates**
  * Updated star icon styling used for favorite state indicators in buttons and table sorting controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->