### PR TITLE
chore(OutlinedQuestionCircleIcon): Update uses of OutlinedQuestionCircleIcon to use RhUiQuestionMarkCircleIcon

### DIFF
--- a/packages/react-core/src/components/Compass/examples/Compass.md
+++ b/packages/react-core/src/components/Compass/examples/Compass.md
@@ -20,7 +20,7 @@ import { useRef, useState, useEffect } from 'react';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
 import OutlinedCopy from '@patternfly/react-icons/dist/esm/icons/outlined-copy-icon';
-import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
+import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 
 import './compass.css';
 

--- a/packages/react-core/src/components/Tooltip/examples/Tooltip.md
+++ b/packages/react-core/src/components/Tooltip/examples/Tooltip.md
@@ -6,7 +6,7 @@ propComponents: ['Tooltip']
 ---
 
 import { useEffect, useRef, useState } from 'react';
-import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
+import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 import './TooltipExamples.css';
 

--- a/packages/react-core/src/demos/Compass/Compass.md
+++ b/packages/react-core/src/demos/Compass/Compass.md
@@ -8,7 +8,7 @@ import { useRef, useState } from 'react';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
 import OutlinedCopy from '@patternfly/react-icons/dist/esm/icons/outlined-copy-icon';
-import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
+import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';

--- a/packages/react-core/src/demos/Compass/examples/CompassDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDemo.tsx
@@ -31,7 +31,7 @@ import {
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
 import OutlinedCopy from '@patternfly/react-icons/dist/esm/icons/outlined-copy-icon';
-import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
+import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 
 export const CompassBasic: React.FunctionComponent = () => {
   const [activeTab, setActiveTab] = useState<number>(0);
@@ -129,7 +129,7 @@ export const CompassBasic: React.FunctionComponent = () => {
             <ActionListGroup>
               <ActionListItem>
                 <Tooltip content="Help">
-                  <Button isCircle variant="plain" icon={<OutlinedQuestionCircleIcon />} aria-label="Help" />
+                  <Button isCircle variant="plain" icon={<RhUiQuestionMarkCircleIcon />} aria-label="Help" />
                 </Tooltip>
               </ActionListItem>
               <ActionListItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: towards #12244 

## Summary

Replaces PatternFly `OutlinedQuestionCircleIcon` with Red Hat UI `RhUiQuestionMarkCircleIcon` in components, examples, and demos, using `@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon` (same pattern as other `RhUi*Icon` imports).

## Files changed

| File | Change |
| --- | --- |
| `packages/react-core/src/demos/Compass/examples/CompassDemo.tsx` | Import and Help `Button` `icon` use `RhUiQuestionMarkCircleIcon` |
| `packages/react-core/src/demos/Compass/Compass.md` | Doc import updated |
| `packages/react-core/src/components/Compass/examples/Compass.md` | Doc import updated |
| `packages/react-core/src/components/Tooltip/examples/Tooltip.md` | Doc import updated |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated question mark circle icons used in Compass and Tooltip component examples and demo documentation to use an alternative icon source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->