### PR TITLE
feat(CodeEditor): add isHighContrastTheme

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps, ReactNode, useEffect, useRef, useState } from 'react';
+import { HTMLProps, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/CodeEditor/code-editor';
 import fileUploadStyles from '@patternfly/react-styles/css/components/FileUpload/file-upload';
@@ -157,6 +157,8 @@ export interface CodeEditorProps extends Omit<HTMLProps<HTMLDivElement>, 'onChan
   isCopyEnabled?: boolean;
   /** Flag indicating the editor is styled using monaco's dark theme. */
   isDarkTheme?: boolean;
+  /** Flag indicating the editor is styled using monaco's high contrast themes. */
+  isHighContrastTheme?: boolean;
   /** Flag that enables component to consume the available height of its container. If `height` prop is set to 100%, this will also become enabled. */
   isFullHeight?: boolean;
   /** Flag indicating the editor has a plain header. */
@@ -286,6 +288,7 @@ export const CodeEditor = ({
   height,
   isCopyEnabled = false,
   isDarkTheme = false,
+  isHighContrastTheme = false,
   isDownloadEnabled = false,
   isFullHeight = false,
   isHeaderPlain = false,
@@ -462,6 +465,13 @@ export const CodeEditor = ({
     headerMainContent ||
     !!shortcutsPopoverProps.bodyContent;
 
+  const theme = useMemo(() => {
+    if (isHighContrastTheme) {
+      return isDarkTheme ? 'hc-black' : 'hc-light';
+    }
+    return isDarkTheme ? 'pf-v6-theme-dark' : 'pf-v6-theme-light';
+  }, [isHighContrastTheme, isDarkTheme]);
+
   return (
     <Dropzone multiple={false} onDropAccepted={onDropAccepted} onDropRejected={onDropRejected}>
       {({ getRootProps, getInputProps, isDragActive, open }) => {
@@ -579,7 +589,7 @@ export const CodeEditor = ({
               onChange={onModelChange}
               onMount={editorDidMount}
               loading={loading}
-              theme={isDarkTheme ? 'pf-v6-theme-dark' : 'pf-v6-theme-light'}
+              theme={theme}
               {...editorProps}
               beforeMount={editorBeforeMount}
             />

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/CodeEditor.test.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/CodeEditor.test.tsx
@@ -2,7 +2,9 @@ import { render, screen, act } from '@testing-library/react';
 import { CodeEditor, Language } from '../CodeEditor';
 import styles from '@patternfly/react-styles/css/components/CodeEditor/code-editor';
 
-jest.mock('@monaco-editor/react', () => jest.fn(() => <div data-testid="mock-editor"></div>));
+jest.mock('@monaco-editor/react', () =>
+  jest.fn((props: any) => <div data-testid="mock-editor" data-theme={props.theme}></div>)
+);
 
 test('Matches snapshot without props', () => {
   const { asFragment } = render(<CodeEditor code="test" />);
@@ -71,4 +73,24 @@ test(`Renders with shortcuts when shortcutsPopoverButtonText is passed`, () => {
     screen.getByText('shortcuts-button').click();
   });
   expect(screen.getByText('shortcuts')).toBeInTheDocument();
+});
+
+test('Uses pf-v6-theme-light by default', () => {
+  render(<CodeEditor code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'pf-v6-theme-light');
+});
+
+test('Uses pf-v6-theme-dark when isDarkTheme is true', () => {
+  render(<CodeEditor isDarkTheme code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'pf-v6-theme-dark');
+});
+
+test('Uses hc-light when isHighContrast is true', () => {
+  render(<CodeEditor isHighContrastTheme code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'hc-light');
+});
+
+test('Uses hc-black when both isHighContrast and isDarkTheme are true', () => {
+  render(<CodeEditor isHighContrastTheme isDarkTheme code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'hc-black');
 });

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
         >
           <div
             data-testid="mock-editor"
+            data-theme="pf-v6-theme-light"
           />
         </div>
       </div>
@@ -196,6 +197,7 @@ exports[`Matches snapshot without props 1`] = `
       >
         <div
           data-testid="mock-editor"
+          data-theme="pf-v6-theme-light"
         />
       </div>
     </div>

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditor.md
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditor.md
@@ -15,6 +15,7 @@ import MapIcon from '@patternfly/react-icons/dist/esm/icons/map-icon';
 import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import FontIcon from '@patternfly/react-icons/dist/esm/icons/font-icon';
+import AdjustIcon from '@patternfly/react-icons/dist/esm/icons/adjust-icon';
 
 ## Examples
 

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorBasic.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorBasic.tsx
@@ -4,12 +4,17 @@ import { Checkbox } from '@patternfly/react-core';
 
 export const CodeEditorBasic: React.FunctionComponent = () => {
   const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const [isHighContrastTheme, setIsHighContrastTheme] = useState(false);
   const [isLineNumbersVisible, setIsLineNumbersVisible] = useState(true);
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [isMinimapVisible, setIsMinimapVisible] = useState(false);
 
   const toggleDarkTheme = (checked) => {
     setIsDarkTheme(checked);
+  };
+
+  const toggleHighContrastTheme = (checked) => {
+    setIsHighContrastTheme(checked);
   };
 
   const toggleLineNumbers = (checked) => {
@@ -44,6 +49,14 @@ export const CodeEditorBasic: React.FunctionComponent = () => {
         name="toggle-theme"
       />
       <Checkbox
+        label="High contrast theme"
+        isChecked={isHighContrastTheme}
+        onChange={(_event, checked) => toggleHighContrastTheme(checked)}
+        aria-label="high contrast theme checkbox"
+        id="toggle-high-contrast-theme"
+        name="toggle-high-contrast-theme"
+      />
+      <Checkbox
         label="Line numbers"
         isChecked={isLineNumbersVisible}
         onChange={(_event, checked) => toggleLineNumbers(checked)}
@@ -69,6 +82,7 @@ export const CodeEditorBasic: React.FunctionComponent = () => {
       />
       <CodeEditor
         isDarkTheme={isDarkTheme}
+        isHighContrastTheme={isHighContrastTheme}
         isLineNumbersVisible={isLineNumbersVisible}
         isReadOnly={isReadOnly}
         isMinimapVisible={isMinimapVisible}

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorConfigurationModal.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorConfigurationModal.tsx
@@ -3,6 +3,7 @@ import MapIcon from '@patternfly/react-icons/dist/esm/icons/map-icon';
 import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
 import HashtagIcon from '@patternfly/react-icons/dist/esm/icons/hashtag-icon';
 import FontIcon from '@patternfly/react-icons/dist/esm/icons/font-icon';
+import AdjustIcon from '@patternfly/react-icons/dist/esm/icons/adjust-icon';
 import { CodeEditor, CodeEditorControl } from '@patternfly/react-code-editor';
 import {
   Flex,
@@ -156,6 +157,7 @@ export const CodeEditorConfigurationModal: React.FunctionComponent = () => {
 
   const [isMinimapVisible, setIsMinimapVisible] = useState(true);
   const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const [isHighContrastTheme, setIsHighContrastTheme] = useState(false);
   const [isLineNumbersVisible, setIsLineNumbersVisible] = useState(true);
   const [fontSize, setFontSize] = useState(14);
 
@@ -180,6 +182,14 @@ export const CodeEditorConfigurationModal: React.FunctionComponent = () => {
         isChecked={isDarkTheme}
         onChange={(_e, checked) => setIsDarkTheme(checked)}
         icon={<MoonIcon />}
+      />
+      <ConfigModalSwitch
+        key="high-contrast-theme-switch"
+        title="High contrast theme"
+        description="Switch the editor to a high contrast color theme"
+        isChecked={isHighContrastTheme}
+        onChange={(_e, checked) => setIsHighContrastTheme(checked)}
+        icon={<AdjustIcon />}
       />
       <ConfigModalSwitch
         key="line-numbers-switch"
@@ -221,6 +231,7 @@ export const CodeEditorConfigurationModal: React.FunctionComponent = () => {
       customControls={customControl}
       height="400px"
       isDarkTheme={isDarkTheme}
+      isHighContrastTheme={isHighContrastTheme}
       isLineNumbersVisible={isLineNumbersVisible}
       isMinimapVisible={isMinimapVisible}
       onChange={onChange}

--- a/packages/react-integration/demo-app-ts/src/components/demos/CodeEditorDemo/CodeEditorDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/CodeEditorDemo/CodeEditorDemo.tsx
@@ -5,6 +5,7 @@ import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 
 interface CodeEditorDemoState {
   isDarkTheme: boolean;
+  isHighContrastTheme: boolean;
   isLineNumbersVisible: boolean;
   isReadOnly: boolean;
   isMinimapVisible: boolean;
@@ -17,6 +18,7 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
     super(props);
     this.state = {
       isDarkTheme: false,
+      isHighContrastTheme: false,
       isLineNumbersVisible: true,
       isReadOnly: false,
       isMinimapVisible: true,
@@ -27,6 +29,12 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
   toggleDarkTheme = (checked: boolean) => {
     this.setState({
       isDarkTheme: checked
+    });
+  };
+
+  toggleHighContrastTheme = (checked: boolean) => {
+    this.setState({
+      isHighContrastTheme: checked
     });
   };
 
@@ -70,8 +78,7 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
   };
 
   render() {
-    const { isDarkTheme, isLineNumbersVisible, isReadOnly, isMinimapVisible, code } = this.state;
-
+    const { isDarkTheme, isHighContrastTheme, isLineNumbersVisible, isReadOnly, isMinimapVisible, code } = this.state;
     const customControl = (
       <CodeEditorControl
         icon={<PlayIcon />}
@@ -90,6 +97,14 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
           aria-label="dark theme checkbox"
           id="toggle-theme"
           name="toggle-theme"
+        />
+        <Checkbox
+          label="High contrast theme"
+          isChecked={isHighContrastTheme}
+          onChange={(_event, checked) => this.toggleHighContrastTheme(checked)}
+          aria-label="high contrast theme checkbox"
+          id="toggle-high-contrast-theme"
+          name="toggle-high-contrast-theme"
         />
         <Checkbox
           label="Line numbers"
@@ -120,6 +135,7 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
         </Button>
         <CodeEditor
           isDarkTheme={isDarkTheme}
+          isHighContrastTheme={isHighContrastTheme}
           isLineNumbersVisible={isLineNumbersVisible}
           isReadOnly={isReadOnly}
           isMinimapVisible={isMinimapVisible}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12383 

Adds a new prop, `isHighContrastTheme`, which switches the CodeEditor over to the monaco-provided `hc-black` and `hc-light` themes (based on the value of `isDarkTheme`) when enabled.

A custom PatternFly variant of the hc-black and hc-light themes can come in a follow up, depending on the direction design wants to take on this


|Dark mode state|Contrast state|Monaco theme|
|-|-|-|
|light theme|no high contrast|<img width="1334" height="980" alt="image" src="https://github.com/user-attachments/assets/9a83f44e-dd77-4615-9c90-8c73af03ed21" />|
|light theme|high contrast|<img width="1334" height="980" alt="image" src="https://github.com/user-attachments/assets/1d681407-f1fa-4b1a-8646-bb3fe8b8e5ec" />|
|dark theme|no high contrast|<img width="1334" height="980" alt="image" src="https://github.com/user-attachments/assets/4b246e3c-0c0d-449b-8147-2054036dc471" />|
|dark theme|high contrast|<img width="1334" height="980" alt="image" src="https://github.com/user-attachments/assets/0eca34b5-4e6d-4096-a218-01ee94d794b5" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high-contrast theme support to the Code Editor.
  * New theme toggle lets users switch between standard, dark, and high-contrast color schemes.
  * Examples, demo, and configuration modal include controls to enable high-contrast mode.
* **Documentation**
  * Example content updated with an icon for the high-contrast control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly-react/pull/12384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->