### PR TITLE
feat(CalendarMonth): add select appendTo passthrough

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -84,8 +84,8 @@ export interface CalendarProps extends CalendarFormat, Omit<React.HTMLProps<HTML
   /** The container to append the month select menu to. Defaults to 'inline'.
    * If your menu is being cut off you can append it to an element higher up the DOM tree.
    * Some examples:
-   * menuAppendTo={() => document.body};
-   * menuAppendTo={document.getElementById('target')}
+   * monthAppendTo={() => document.body};
+   * monthAppendTo={document.getElementById('target')}
    */
   monthAppendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement) | 'inline';
 }

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { TextInput } from '../TextInput';
 import { Button } from '../Button';
-import { Select, SelectList, SelectOption } from '../Select';
+import { Select, SelectList, SelectOption, SelectProps } from '../Select';
 import { MenuToggle, MenuToggleElement } from '../MenuToggle';
 import { InputGroup, InputGroupItem } from '../InputGroup';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
@@ -81,6 +81,8 @@ export interface CalendarProps extends CalendarFormat, Omit<React.HTMLProps<HTML
   onSelectToggle?: (open: boolean) => void;
   /** Functions that returns if a date is valid and selectable. */
   validators?: ((date: Date) => boolean)[];
+  /** Additional props passed to the month select component. */
+  monthSelectProps?: SelectProps;
 }
 
 const buildCalendar = (year: number, month: number, weekStart: number, validators: ((date: Date) => boolean)[]) => {
@@ -143,6 +145,7 @@ export const CalendarMonth = ({
   cellAriaLabel,
   isDateFocused = false,
   inlineProps,
+  monthSelectProps,
   ...props
 }: CalendarProps) => {
   const longMonths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -328,6 +331,7 @@ export const CalendarMonth = ({
                 }}
                 selected={monthFormatted}
                 popperProps={{ appendTo: 'inline' }}
+                {...monthSelectProps}
               >
                 <SelectList>
                   {longMonths.map((longMonth, index) => (

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { TextInput } from '../TextInput';
 import { Button } from '../Button';
-import { Select, SelectList, SelectOption, SelectProps } from '../Select';
+import { Select, SelectList, SelectOption } from '../Select';
 import { MenuToggle, MenuToggleElement } from '../MenuToggle';
 import { InputGroup, InputGroupItem } from '../InputGroup';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
@@ -81,8 +81,13 @@ export interface CalendarProps extends CalendarFormat, Omit<React.HTMLProps<HTML
   onSelectToggle?: (open: boolean) => void;
   /** Functions that returns if a date is valid and selectable. */
   validators?: ((date: Date) => boolean)[];
-  /** Additional props passed to the month select component. */
-  monthSelectProps?: SelectProps;
+  /** The container to append the month select menu to. Defaults to 'inline'.
+   * If your menu is being cut off you can append it to an element higher up the DOM tree.
+   * Some examples:
+   * menuAppendTo={() => document.body};
+   * menuAppendTo={document.getElementById('target')}
+   */
+  monthAppendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement) | 'inline';
 }
 
 const buildCalendar = (year: number, month: number, weekStart: number, validators: ((date: Date) => boolean)[]) => {
@@ -145,7 +150,7 @@ export const CalendarMonth = ({
   cellAriaLabel,
   isDateFocused = false,
   inlineProps,
-  monthSelectProps,
+  monthAppendTo = 'inline',
   ...props
 }: CalendarProps) => {
   const longMonths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -330,8 +335,7 @@ export const CalendarMonth = ({
                   onMonthChange(ev, newDate);
                 }}
                 selected={monthFormatted}
-                popperProps={{ appendTo: 'inline' }}
-                {...monthSelectProps}
+                popperProps={{ appendTo: monthAppendTo }}
               >
                 <SelectList>
                   {longMonths.map((longMonth, index) => (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12414

Allows a user to override the select `appendTo` if their user case requires a different configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The calendar month dropdown can now be configured to control where its menu is appended, enabling the dropdown to render into a custom container when needed.
  * Default behavior remains unchanged: the month menu continues to append inline unless a different target is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->