### PR TITLE
chore(Compass): move docs to 'components'

### DIFF
--- a/packages/react-core/src/components/Compass/examples/Compass.md
+++ b/packages/react-core/src/components/Compass/examples/Compass.md
@@ -1,8 +1,7 @@
 ---
 id: Compass
 cssPrefix: pf-v6-c-compass
-section: AI
-subsection: Generative UIs
+section: components
 beta: true
 propComponents:
   [

--- a/packages/react-core/src/demos/Compass/Compass.md
+++ b/packages/react-core/src/demos/Compass/Compass.md
@@ -1,7 +1,6 @@
 ---
 id: Compass
-section: AI
-subsection: Generative UIs
+section: components
 ---
 
 import { useRef, useState, useEffect } from 'react';

--- a/packages/react-docs/patternfly-docs/patternfly-docs.config.js
+++ b/packages/react-docs/patternfly-docs/patternfly-docs.config.js
@@ -12,7 +12,6 @@ module.exports = {
     { section: 'components' },
     { section: 'patterns' },
     { section: 'foundations-and-styles' },
-    { section: 'AI' },
     { section: 'developer-guides' }
   ],
   topNavItems: [{ text: 'Icons', path: '/icons' }],


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://redhat.atlassian.net/browse/PF-4080

Moves compass component docs and demos to Components section and removes AI / generative AI sections from react workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Compass component documentation by reclassifying it from the AI section to the components section.
  * Updated the documentation navigation menu by removing the AI section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->