### PR TITLE
fix(Label): extend clickable hit area to full label bounds (#12367)

### DIFF
--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -285,7 +285,7 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   let LabelComponentChildElement = 'span';
   if (href) {
     LabelComponentChildElement = 'a';
-  } else if (isEditable || (onLabelClick && !isOverflowLabel && !isAddLabel)) {
+  } else if (isEditable || (onLabelClick && !isOverflowLabel && !isAddLabel && onClose)) {
     LabelComponentChildElement = 'button';
   }
 
@@ -338,7 +338,9 @@ export const Label: React.FunctionComponent<LabelProps> = ({
     );
   }
 
-  const LabelComponent = (isOverflowLabel || isAddLabel ? 'button' : 'span') as any;
+  const LabelComponent = (
+    isOverflowLabel || isAddLabel || (!!onLabelClick && !isEditable && !onClose) ? 'button' : 'span'
+  ) as any;
 
   return (
     <LabelComponent
@@ -358,8 +360,9 @@ export const Label: React.FunctionComponent<LabelProps> = ({
         isAddLabel && styles.modifiers.add,
         className
       )}
-      onClick={isOverflowLabel || isAddLabel ? onLabelClick : undefined}
+      onClick={isOverflowLabel || isAddLabel || (!!onLabelClick && !isEditable && !onClose) ? onLabelClick : undefined}
       {...(LabelComponent === 'button' && { type: 'button' })}
+      {...(isClickableDisabled && !!onLabelClick && !isEditable && !onClose && { disabled: true })}
     >
       {!isEditableActive && labelComponentChild}
       {!isEditableActive && onClose && closeButton}


### PR DESCRIPTION
## Description

Fixes patternfly/patternfly#8430

When a `<Label>` has an `onClick` handler, the outer `<span class="pf-v6-c-label">` 
has padding/border that is visually part of the label but clicking that region did 
not trigger `onClick` — only the inner `<button class="pf-v6-c-label__content">` 
was interactive.

## Changes

- When `onClick` is provided and no `onClose` is present, the outer element is promoted 
from a `<span>` to a `<button>`, so the full visual area including padding and border 
is part of the hit target. The inner element becomes a plain `<span>`, removing the 
semantically problematic nested button.

**Before:**
```html
<span class="pf-v6-c-label pf-m-clickable">      
  <button class="pf-v6-c-label__content">...</button>  
</span>
```

**After:**
```html
<button class="pf-v6-c-label pf-m-clickable">
  <span class="pf-v6-c-label__content">...</span>
</button>
```

- `disabled` is now applied to the outer <button> for the promoted clickable case. Previously it was applied to the inner <button> via isClickableDisabled && isButton, but since the inner element is now a plain <span> in this case, isButton is false and that guard no longer fires. This preserves the existing isDisabled behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Label component click handling to properly account for the `onClose` callback, improving interaction behavior consistency when multiple event handlers are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->