### PR TITLE
feat(Table): add indeterminate checkbox state support for select-all header

### DIFF
--- a/packages/react-table/src/components/Table/SelectColumn.tsx
+++ b/packages/react-table/src/components/Table/SelectColumn.tsx
@@ -21,6 +21,8 @@ export interface SelectColumnProps {
   id?: string;
   /** name for the input element - required by Radio component */
   name?: string;
+  /** Whether the checkbox should be in an indeterminate state */
+  isIndeterminate?: boolean;
 }
 
 export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
@@ -33,12 +35,22 @@ export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
   tooltipProps,
   id,
   name,
+  isIndeterminate,
   ...props
 }: SelectColumnProps) => {
   const inputRef = createRef<any>();
 
   const handleChange = (event: React.FormEvent<HTMLInputElement>, _checked: boolean) => {
     onSelect && onSelect(event);
+  };
+
+  // PatternFly Checkbox supports indeterminate via isChecked: null
+  const checkboxProps = {
+    ...props,
+    id,
+    ref: inputRef,
+    onChange: handleChange,
+    ...(isIndeterminate && { isChecked: null })
   };
 
   const commonProps = {
@@ -51,7 +63,7 @@ export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
   const content = (
     <Fragment>
       {selectVariant === RowSelectVariant.checkbox ? (
-        <Checkbox {...commonProps} />
+        <Checkbox {...checkboxProps} />
       ) : (
         <Radio {...commonProps} name={name} />
       )}

--- a/packages/react-table/src/components/Table/SelectColumn.tsx
+++ b/packages/react-table/src/components/Table/SelectColumn.tsx
@@ -44,20 +44,16 @@ export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
     onSelect && onSelect(event);
   };
 
-  // PatternFly Checkbox supports indeterminate via isChecked: null
-  const checkboxProps = {
-    ...props,
-    id,
-    ref: inputRef,
-    onChange: handleChange,
-    ...(isIndeterminate && { isChecked: null })
-  };
-
   const commonProps = {
     ...props,
     id,
     ref: inputRef,
     onChange: handleChange
+  };
+
+  const checkboxProps = {
+    ...commonProps,
+    ...(isIndeterminate && { isChecked: null })
   };
 
   const content = (

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -107,6 +107,7 @@ export interface IColumn {
     allRowsSelected?: boolean;
     allRowsExpanded?: boolean;
     isHeaderSelectDisabled?: boolean;
+    isIndeterminate?: boolean;
     onFavorite?: OnFavorite;
     favoriteButtonProps?: ButtonProps;
     variant?: 'compact';

--- a/packages/react-table/src/components/Table/Th.tsx
+++ b/packages/react-table/src/components/Table/Th.tsx
@@ -158,7 +158,8 @@ const ThBase: React.FunctionComponent<ThProps> = ({
             onSelect: select?.onSelect,
             selectVariant: 'checkbox',
             allRowsSelected: select.isSelected,
-            isHeaderSelectDisabled: !!select.isHeaderSelectDisabled
+            isHeaderSelectDisabled: !!select.isHeaderSelectDisabled,
+            isIndeterminate: select?.isIndeterminate
           }
         },
         tooltip: tooltip as string,

--- a/packages/react-table/src/components/Table/__tests__/Th.test.tsx
+++ b/packages/react-table/src/components/Table/__tests__/Th.test.tsx
@@ -54,3 +54,26 @@ test('Additional content renders after children when additionalContent is passed
   expect(thChildren.item(0)?.textContent).toEqual('Test');
   expect(thChildren.item(1)?.textContent).toEqual('Extra');
 });
+
+test('Renders checkbox without indeterminate state by default', () => {
+  render(<Th select={{ onSelect: jest.fn(), isSelected: false }} aria-label="Select all" />);
+
+  const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+  expect(checkbox).not.toBeChecked();
+  expect(checkbox.indeterminate).toBe(false);
+});
+
+test('Renders checkbox with indeterminate state when isIndeterminate is true', () => {
+  render(<Th select={{ onSelect: jest.fn(), isSelected: false, isIndeterminate: true }} aria-label="Select all" />);
+
+  const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+  expect(checkbox.indeterminate).toBe(true);
+});
+
+test('Renders checked checkbox when isSelected is true and isIndeterminate is false', () => {
+  render(<Th select={{ onSelect: jest.fn(), isSelected: true, isIndeterminate: false }} aria-label="Select all" />);
+
+  const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+  expect(checkbox).toBeChecked();
+  expect(checkbox.indeterminate).toBe(false);
+});

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -180,6 +180,8 @@ export interface ThSelectType {
   onSelect?: OnSelect;
   /** Whether the cell is selected */
   isSelected: boolean;
+  /** Whether the select checkbox should be in an indeterminate state (some items selected) */
+  isIndeterminate?: boolean;
   /** Flag indicating the select checkbox in the th is disabled */
   isHeaderSelectDisabled?: boolean;
   /** Whether to disable the selection */

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -158,6 +158,14 @@ checking checkboxes will check intermediate rows' checkboxes.
 
 ```
 
+### Selectable with indeterminate state
+
+This example demonstrates the indeterminate state support for the select-all checkbox. When some (but not all) rows are selected, the header checkbox displays a dash/minus icon to indicate partial selection.
+
+```ts file="TableSelectableIndeterminate.tsx"
+
+```
+
 ### Selectable radio input
 
 Similarly to the selectable example above, the radio buttons use the first column. The first header cell is empty, and each body row's first cell has radio button props.

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -160,7 +160,7 @@ checking checkboxes will check intermediate rows' checkboxes.
 
 ### Selectable with indeterminate state
 
-This example demonstrates the indeterminate state support for the select-all checkbox. When some (but not all) rows are selected, the header checkbox displays a dash/minus icon to indicate partial selection.
+To indicate partial selection, use `isIndeterminate` on the header's `select` prop. When some (but not all) selectable rows are selected, the header checkbox will convey this information to assistive technologies and also display a dash instead of a checkmark.
 
 ```ts file="TableSelectableIndeterminate.tsx"
 

--- a/packages/react-table/src/components/Table/examples/TableSelectableIndeterminate.tsx
+++ b/packages/react-table/src/components/Table/examples/TableSelectableIndeterminate.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+
+interface Repository {
+  name: string;
+  branches: string;
+  prs: string;
+  workspaces: string;
+  lastCommit: string;
+}
+
+export const TableSelectableIndeterminate: React.FunctionComponent = () => {
+  // In real usage, this data would come from some external source like an API via props.
+  const repositories: Repository[] = [
+    { name: 'one', branches: 'two', prs: 'a', workspaces: 'four', lastCommit: 'five' },
+    { name: 'a', branches: 'two', prs: 'k', workspaces: 'four', lastCommit: 'five' },
+    { name: 'b', branches: 'two', prs: 'k', workspaces: 'four', lastCommit: 'five' },
+    { name: 'c', branches: 'two', prs: 'k', workspaces: 'four', lastCommit: 'five' },
+    { name: 'd', branches: 'two', prs: 'k', workspaces: 'four', lastCommit: 'five' },
+    { name: 'e', branches: 'two', prs: 'b', workspaces: 'four', lastCommit: 'five' }
+  ];
+
+  const columnNames = {
+    name: 'Repositories',
+    branches: 'Branches',
+    prs: 'Pull requests',
+    workspaces: 'Workspaces',
+    lastCommit: 'Last commit'
+  };
+
+  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
+  const selectableRepos = repositories.filter(isRepoSelectable);
+
+  // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
+  // This is to prevent state from being based on row order index in case we later add sorting.
+  const [selectedRepoNames, setSelectedRepoNames] = useState<string[]>([]);
+  const setRepoSelected = (repo: Repository, isSelecting = true) =>
+    setSelectedRepoNames((prevSelected) => {
+      const otherSelectedRepoNames = prevSelected.filter((r) => r !== repo.name);
+      return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
+    });
+  const selectAllRepos = (isSelecting = true) =>
+    setSelectedRepoNames(isSelecting ? selectableRepos.map((r) => r.name) : []);
+  const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+  const areSomeReposSelected = selectedRepoNames.length > 0 && selectedRepoNames.length < selectableRepos.length;
+  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = useState<number | null>(null);
+  const [shifting, setShifting] = useState(false);
+
+  const onSelectRepo = (repo: Repository, rowIndex: number, isSelecting: boolean) => {
+    // If the user is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(new Array(numberSelected + 1), (_x, i) => i + recentSelectedRowIndex)
+          : Array.from(new Array(Math.abs(numberSelected) + 1), (_x, i) => i + rowIndex);
+      intermediateIndexes.forEach((index) => setRepoSelected(repositories[index], isSelecting));
+    } else {
+      setRepoSelected(repo, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+  };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  return (
+    <Table aria-label="Selectable table with indeterminate state">
+      <Thead>
+        <Tr>
+          <Th
+            select={{
+              onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
+              isSelected: areAllReposSelected,
+              isIndeterminate: areSomeReposSelected
+            }}
+            aria-label="Row select"
+          />
+          <Th>{columnNames.name}</Th>
+          <Th>{columnNames.branches}</Th>
+          <Th>{columnNames.prs}</Th>
+          <Th>{columnNames.workspaces}</Th>
+          <Th>{columnNames.lastCommit}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {repositories.map((repo, rowIndex) => (
+          <Tr key={repo.name}>
+            <Td
+              select={{
+                rowIndex,
+                onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
+                isSelected: isRepoSelected(repo),
+                isDisabled: !isRepoSelectable(repo)
+              }}
+            />
+            <Td dataLabel={columnNames.name}>{repo.name}</Td>
+            <Td dataLabel={columnNames.branches}>{repo.branches}</Td>
+            <Td dataLabel={columnNames.prs}>{repo.prs}</Td>
+            <Td dataLabel={columnNames.workspaces}>{repo.workspaces}</Td>
+            <Td dataLabel={columnNames.lastCommit}>{repo.lastCommit}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};

--- a/packages/react-table/src/components/Table/utils/decorators/selectable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/selectable.tsx
@@ -9,7 +9,7 @@ export const selectable: ITransform = (
   { rowIndex, columnIndex, rowData, column, property, tooltip }: IExtra
 ) => {
   const {
-    extraParams: { onSelect, selectVariant, allRowsSelected, isHeaderSelectDisabled }
+    extraParams: { onSelect, selectVariant, allRowsSelected, isHeaderSelectDisabled, isIndeterminate }
   } = column;
   const extraData = {
     rowIndex,
@@ -70,6 +70,7 @@ export const selectable: ITransform = (
         onSelect={selectClick}
         name={selectName}
         tooltip={tooltip}
+        isIndeterminate={rowId === -1 ? isIndeterminate : undefined}
       >
         {label as React.ReactNode}
       </SelectColumn>


### PR DESCRIPTION
## Summary

Adds support for indeterminate state to the Table component's select-all checkbox in the header, following PatternFly's [bulk selection design guidelines](https://www.patternfly.org/patterns/bulk-selection/).

The select-all checkbox now properly supports three states:
- **Unchecked** - no items selected
- **Indeterminate** (dash/minus icon) - some items selected
- **Checked** - all items selected

## Changes

- Added `isIndeterminate?: boolean` property to `ThSelectType` interface
- Added `isIndeterminate?: boolean` to `IColumn` extraParams type
- Updated `Th` component to pass `isIndeterminate` to the selectable decorator
- Updated `selectable` decorator to pass indeterminate state to `SelectColumn`
- Updated `SelectColumn` to use PatternFly Checkbox's native indeterminate support (isChecked: null)
- Added new `TableSelectableIndeterminate` example showcasing the feature

## Technical implementation

The indeterminate state is implemented using the PatternFly Checkbox component's native support by setting `isChecked: null` when `isIndeterminate` is true. This leverages PatternFly's built-in indeterminate checkbox handling.

```typescript
<Checkbox
  isChecked={isIndeterminate ? null : isSelected}
  // ... other props
/>
```

## Usage example

```typescript
const areSomeReposSelected = selectedRepoNames.length > 0 && selectedRepoNames.length < selectableRepos.length;

<Th
  select={{
    onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
    isSelected: areAllReposSelected,
    isIndeterminate: areSomeReposSelected  // NEW: shows dash when some selected
  }}
  aria-label="Row select"
/>
```

## Related issues

- Fixes #12404
- Related to closed issues #3648 and PR #3909
- Jira: [PF-4099](https://redhat.atlassian.net/browse/PF-4099)

## Test plan

- [ ] Build passes without TypeScript errors
- [ ] Visual testing of TableSelectableIndeterminate example shows indeterminate state when some rows selected
- [ ] Accessibility: Screen readers properly announce the checkbox state
- [ ] Checkbox toggles correctly between all three states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables support an indeterminate select-all state in the header, showing a dash when only some selectable rows are chosen; row selection honors shift+click range selection.
* **Documentation**
  * Added example and docs describing indeterminate header selection behavior and accessibility notes.
* **Tests**
  * Added tests verifying header checkbox indeterminate/checked/unchecked states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->