### PR TITLE
fix(DragDropSort): support custom drag button aria-label and fix falsy id overlay

### DIFF
--- a/packages/react-drag-drop/src/components/DragDrop/DragDropContainer.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/DragDropContainer.tsx
@@ -111,7 +111,7 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
 
   const collisionDetectionStrategy: CollisionDetection = useCallback(
     (args) => {
-      if (activeId && activeId in items) {
+      if (activeId != null && activeId in items) {
         return closestCenter({
           ...args,
           droppableContainers: args.droppableContainers.filter((container) => container.id in items)
@@ -144,7 +144,7 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
       if (hasRecentlyMovedContainer.current) {
         lastOverId.current = activeId;
       }
-      return lastOverId.current ? [{ id: lastOverId.current }] : [];
+      return lastOverId.current != null ? [{ id: lastOverId.current }] : [];
     },
     [activeId, items]
   );
@@ -168,7 +168,7 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
     const { id: activeId } = active;
     const { id: overId } = over;
 
-    if (!overId || activeId in items) {
+    if (overId == null || activeId in items) {
       return;
     }
 
@@ -240,7 +240,7 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
   };
 
   const getDragOverlay = () => {
-    if (!activeId) {
+    if (activeId == null) {
       return;
     }
     const item = findItem(activeId, findContainer(activeId));
@@ -290,7 +290,7 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
     );
   };
 
-  const dragOverlay = <DragOverlay>{activeId && getDragOverlay()}</DragOverlay>;
+  const dragOverlay = <DragOverlay>{activeId != null && getDragOverlay()}</DragOverlay>;
 
   const portalTarget = typeof appendTo === 'function' ? appendTo() : appendTo || document.body;
 

--- a/packages/react-drag-drop/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/Draggable.tsx
@@ -13,6 +13,8 @@ export interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
   id?: string;
   /** Flag indicating the draggable element should include a drag button. */
   useDragButton?: boolean;
+  /** Accessible name of the drag button. */
+  dragButtonAriaLabel?: string;
 }
 
 export const Draggable: React.FunctionComponent<DraggableProps> = ({
@@ -20,6 +22,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   id,
   className,
   useDragButton = false,
+  dragButtonAriaLabel,
   ...props
 }: DraggableProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -38,7 +41,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
       style={style}
       {...props}
     >
-      <DragButton {...attributes} {...listeners} />
+      <DragButton {...attributes} {...listeners} {...(dragButtonAriaLabel && { 'aria-label': dragButtonAriaLabel })} />
       {children}
     </div>
   ) : (


### PR DESCRIPTION
**What**: Closes https://github.com/patternfly/patternfly-react/issues/12416

- Adds a `dragButtonAriaLabel` prop to `Draggable` that forwards to `DragButton`, allowing consumers to provide a translated accessible name for the drag handle via `DraggableObject.props`.
- Fixes `DragDropContainer` rendering the literal text `"0"` as the drag overlay when a draggable item has a falsy numeric id (e.g. `0`). The `activeId && getDragOverlay()` expression short-circuits to `0` which React renders as text. Changed to `activeId != null`.

**Additional issues**: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drag-overlay and drop-target detection to correctly handle all valid identifiers (including falsy-but-valid values like 0), preventing unintended overlay suppression and ensuring consistent collision/visual feedback during dragging.

* **New Features**
  * Added optional aria-label support for drag buttons so drag handles can include an accessible name when enabled, improving assistive technology support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->