### PR TITLE
fix(DragDropSort): enable mobile drag-and-drop support

### DIFF
--- a/packages/react-drag-drop/src/components/DragDrop/DragButton.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/DragButton.tsx
@@ -27,6 +27,7 @@ export const DragButton: React.FunctionComponent<DragButtonProps> = ({
     className={css(className)}
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledby}
+    style={{ touchAction: 'none' }}
     icon={
       <span className={css(dragButtonStyles.dataListItemDraggableIcon)}>
         <RhUiGripVerticalFillIcon />

--- a/packages/react-drag-drop/src/components/DragDrop/DragDropContainer.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/DragDropContainer.tsx
@@ -21,6 +21,7 @@ import {
   DragCancelEvent
 } from '@dnd-kit/core';
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { Draggable } from './Draggable';
 import { DraggableDataListItem } from './DraggableDataListItem';
 import { DraggableDualListSelectorListItem } from './DraggableDualListSelectorListItem';
@@ -103,7 +104,9 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
   );
 
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 }
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates
     })
@@ -298,6 +301,7 @@ export const DragDropContainer: React.FunctionComponent<DragDropContainerProps> 
     <DndContext
       sensors={sensors}
       collisionDetection={collisionDetectionStrategy}
+      modifiers={[restrictToWindowEdges]}
       onDragEnd={handleDragEnd}
       onDragOver={handleDragOver}
       onDragStart={handleDragStart}

--- a/packages/react-drag-drop/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/Draggable.tsx
@@ -31,7 +31,8 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
 
   const style = {
     transform: CSS.Transform.toString(transform),
-    transition
+    transition,
+    ...(!useDragButton && { touchAction: 'none' as const })
   };
 
   return useDragButton ? (


### PR DESCRIPTION
**What**: Closes https://github.com/patternfly/patternfly-react/issues/12415

Three changes to enable mobile drag-and-drop:

1. **`Draggable`**: Set `touch-action: none` on the drag activator element — on `DragButton` when `useDragButton` is true (so only the handle blocks native scrolling), on the wrapper div otherwise. Without this, mobile browsers fire `pointercancel` before the `PointerSensor` can activate.

2. **`DragDropContainer`**: Add `activationConstraint: { distance: 8 }` to `PointerSensor` so the drag only activates after 8px of deliberate pointer movement, preventing accidental drags on both desktop and mobile.

3. **`DragDropContainer`**: Add `restrictToWindowEdges` modifier to `DndContext` so dragged items cannot be moved outside the browser viewport. Placed before `{...props}` so consumers can override via the `modifiers` prop.

**Additional issues**: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag now requires a small deliberate pointer movement before starting, reducing accidental drags.
  * Drag movement is constrained to the visible window, preventing items from being dragged off-screen.
* **Bug Fixes / Improvements**
  * Touch gesture handling refined: touch-action is applied appropriately to prevent unintended scrolling, including when using a drag handle/button.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly-react/pull/12418)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->