### PR TITLE
fix(Spinner): define default aria-label via destructuring

### DIFF
--- a/packages/react-core/src/components/Spinner/Spinner.tsx
+++ b/packages/react-core/src/components/Spinner/Spinner.tsx
@@ -32,7 +32,7 @@ export const Spinner: React.FunctionComponent<SpinnerProps> = ({
   'aria-valuetext': ariaValueText = 'Loading...',
   diameter,
   isInline = false,
-  'aria-label': ariaLabel,
+  'aria-label': ariaLabel = 'Contents',
   'aria-labelledBy': ariaLabelledBy,
   ...props
 }: SpinnerProps) => (
@@ -42,9 +42,8 @@ export const Spinner: React.FunctionComponent<SpinnerProps> = ({
     aria-valuetext={ariaValueText}
     viewBox="0 0 100 100"
     {...(diameter && { style: { [cssDiameter.name]: diameter } as React.CSSProperties })}
-    {...(ariaLabel && { 'aria-label': ariaLabel })}
+    aria-label={ariaLabel}
     {...(ariaLabelledBy && { 'aria-labelledBy': ariaLabelledBy })}
-    {...(!ariaLabel && !ariaLabelledBy && { 'aria-label': 'Contents' })}
     {...props}
   >
     <circle className={styles.spinnerPath} cx="50" cy="50" r="45" fill="none" />

--- a/packages/react-core/src/components/Spinner/Spinner.tsx
+++ b/packages/react-core/src/components/Spinner/Spinner.tsx
@@ -43,7 +43,7 @@ export const Spinner: React.FunctionComponent<SpinnerProps> = ({
     viewBox="0 0 100 100"
     {...(diameter && { style: { [cssDiameter.name]: diameter } as React.CSSProperties })}
     aria-label={ariaLabel}
-    {...(ariaLabelledBy && { 'aria-labelledBy': ariaLabelledBy })}
+    {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}
     {...props}
   >
     <circle className={styles.spinnerPath} cx="50" cy="50" r="45" fill="none" />

--- a/packages/react-core/src/components/Spinner/Spinner.tsx
+++ b/packages/react-core/src/components/Spinner/Spinner.tsx
@@ -22,8 +22,10 @@ export interface SpinnerProps extends React.SVGProps<SVGSVGElement> {
   isInline?: boolean;
   /** Accessible label to describe what is loading */
   'aria-label'?: string;
-  /** Id of element which describes what is being loaded */
+  /** ID of the element(s) that provide an accessible name for the spinner. This prop is deprecated and you should instead use the aria-labelledby prop (with a lowercase "b") instead. */
   'aria-labelledBy'?: string;
+  /** ID of the element(s) that provide an accessible name for the spinner. */
+  'aria-labelledby'?: string;
 }
 
 export const Spinner: React.FunctionComponent<SpinnerProps> = ({
@@ -33,7 +35,8 @@ export const Spinner: React.FunctionComponent<SpinnerProps> = ({
   diameter,
   isInline = false,
   'aria-label': ariaLabel = 'Contents',
-  'aria-labelledBy': ariaLabelledBy,
+  'aria-labelledBy': deprecatedAriaLabelledBy,
+  'aria-labelledby': ariaLabelledby,
   ...props
 }: SpinnerProps) => (
   <svg
@@ -43,7 +46,9 @@ export const Spinner: React.FunctionComponent<SpinnerProps> = ({
     viewBox="0 0 100 100"
     {...(diameter && { style: { [cssDiameter.name]: diameter } as React.CSSProperties })}
     aria-label={ariaLabel}
-    {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}
+    {...((ariaLabelledby ?? deprecatedAriaLabelledBy) && {
+      'aria-labelledby': ariaLabelledby ?? deprecatedAriaLabelledBy
+    })}
     {...props}
   >
     <circle className={styles.spinnerPath} cx="50" cy="50" r="45" fill="none" />

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -16,7 +16,7 @@ test('uses a custom aria-label when one is provided', () => {
   expect(screen.getByRole('progressbar')).toHaveAccessibleName('Loading users');
 });
 
-test('keeps the default aria-label when aria-labelledby is provided', () => {
+test('Renders with accessible name via aria-labelledby when passed', () => {
   render(
     <>
       <span id="spinner-label">Loading reports</span>
@@ -24,10 +24,12 @@ test('keeps the default aria-label when aria-labelledby is provided', () => {
     </>
   );
 
-  const spinner = screen.getByRole('progressbar');
-  expect(spinner).toHaveAttribute('aria-label', 'Contents');
-  expect(spinner).toHaveAttribute('aria-labelledby', 'spinner-label');
-  expect(spinner).toHaveAccessibleName('Loading reports');
+  expect(screen.getByRole('progressbar')).toHaveAccessibleName('Loading reports');
+});
+
+test('Renders with aria-label even when aria-labelledby is passed', () => {
+  render(<Spinner aria-labelledby="external-label" />);
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Contents');
 });
 
 test('small spinner', () => {

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -29,7 +29,7 @@ test('Renders with accessible name via aria-labelledby when passed', () => {
 
 test('Renders with aria-label even when aria-labelledby is passed', () => {
   render(<Spinner aria-labelledby="external-label" />);
-  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Contents');
+  expect(screen.getByRole('progressbar')).toHaveAccessibleName('Contents');
 });
 
 test('small spinner', () => {

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -8,12 +8,26 @@ test('simple spinner', () => {
 
 test('uses default aria-label of "Contents" when none is provided', () => {
   render(<Spinner />);
-  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Contents');
+  expect(screen.getByRole('progressbar')).toHaveAccessibleName('Contents');
 });
 
 test('uses a custom aria-label when one is provided', () => {
   render(<Spinner aria-label="Loading users" />);
-  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Loading users');
+  expect(screen.getByRole('progressbar')).toHaveAccessibleName('Loading users');
+});
+
+test('keeps the default aria-label when aria-labelledby is provided', () => {
+  render(
+    <>
+      <span id="spinner-label">Loading reports</span>
+      <Spinner aria-labelledby="spinner-label" />
+    </>
+  );
+
+  const spinner = screen.getByRole('progressbar');
+  expect(spinner).toHaveAttribute('aria-label', 'Contents');
+  expect(spinner).toHaveAttribute('aria-labelledby', 'spinner-label');
+  expect(spinner).toHaveAccessibleName('Loading reports');
 });
 
 test('small spinner', () => {

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -1,9 +1,24 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Spinner } from '../Spinner';
 
 test('simple spinner', () => {
   const { asFragment } = render(<Spinner />);
   expect(asFragment()).toMatchSnapshot();
+});
+
+test('uses default aria-label of "Contents" when none is provided', () => {
+  render(<Spinner />);
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Contents');
+});
+
+test('uses a custom aria-label when one is provided', () => {
+  render(<Spinner aria-label="Loading users" />);
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Loading users');
+});
+
+test('renders aria-labelledBy when provided', () => {
+  render(<Spinner aria-labelledBy="external-label" />);
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-labelledBy', 'external-label');
 });
 
 test('small spinner', () => {

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -16,11 +16,6 @@ test('uses a custom aria-label when one is provided', () => {
   expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Loading users');
 });
 
-test('renders aria-labelledBy when provided', () => {
-  render(<Spinner aria-labelledBy="external-label" />);
-  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-labelledBy', 'external-label');
-});
-
 test('small spinner', () => {
   const { asFragment } = render(<Spinner size="sm" />);
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -27,9 +27,14 @@ test('Renders with accessible name via aria-labelledby when passed', () => {
   expect(screen.getByRole('progressbar')).toHaveAccessibleName('Loading reports');
 });
 
-test('Renders legacy aria-labelledBy as aria-labelledby', () => {
+test('Renders deprecated aria-labelledBy as aria-labelledby', () => {
   render(<Spinner aria-labelledBy="external-label" />);
   expect(screen.getByRole('progressbar')).toHaveAttribute('aria-labelledby', 'external-label');
+});
+
+test('Prefers aria-labelledby over the deprecated aria-labelledBy when both are passed', () => {
+  render(<Spinner aria-labelledby="lowercase-label" aria-labelledBy="deprecated-label" />);
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-labelledby', 'lowercase-label');
 });
 
 test('Renders with aria-label even when aria-labelledby is passed', () => {

--- a/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -27,6 +27,11 @@ test('Renders with accessible name via aria-labelledby when passed', () => {
   expect(screen.getByRole('progressbar')).toHaveAccessibleName('Loading reports');
 });
 
+test('Renders legacy aria-labelledBy as aria-labelledby', () => {
+  render(<Spinner aria-labelledBy="external-label" />);
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-labelledby', 'external-label');
+});
+
 test('Renders with aria-label even when aria-labelledby is passed', () => {
   render(<Spinner aria-labelledby="external-label" />);
   expect(screen.getByRole('progressbar')).toHaveAccessibleName('Contents');


### PR DESCRIPTION
**What**: Closes #11750

The Spinner component's default `aria-label` of "Contents" was emitted by an inline conditional in the JSX (`{...(!ariaLabel && !ariaLabelledBy && { 'aria-label': 'Contents' })}`), so the props table for the component didn't show that there was a default value at all. Per the maintainer's edit on the issue, this PR is scoped to *just* updating how that default is defined.

The destructuring now sets the default directly:

```tsx
'aria-label': ariaLabel = 'Contents',
```

and the three conditional spreads in the JSX collapse to a direct `aria-label={ariaLabel}` plus the still-conditional `aria-labelledBy` spread.

**Behavior**

- Existing snapshots are unchanged: `<Spinner />` still renders `aria-label="Contents"`.
- An explicitly passed `aria-label` continues to take precedence.
- A consumer that only provides `aria-labelledBy` will now also see the default `aria-label="Contents"` on the SVG. The two ARIA attributes coexist (per WAI-ARIA, an assistive technology will use `aria-labelledby` when both are present), and this matches the existing pattern for sibling components like `TabAction`, `DrawerCloseButton`, `PageToggleButton`, and `FileUploadField` that all use destructuring defaults for `aria-label`.

**Tests**

Added three unit tests covering the default value, an explicitly provided value, and `aria-labelledBy` propagation. Existing snapshot tests still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the Spinner’s accessibility labeling so the progress indicator consistently uses a default ARIA label of **“Contents”**, while still honoring `aria-labelledby` when provided.

* **Tests**
  * Expanded Spinner accessibility coverage to verify:
    * the default ARIA label when no label props are provided,
    * correct behavior when an explicit ARIA label is set,
    * that the default label behavior continues to apply when `aria-labelledby` is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->