### PR TITLE
fix(Modal): exclude Poppers in aria-hidden change

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -111,7 +111,8 @@ class Modal extends Component<ModalProps, ModalState> {
     const target: HTMLElement = this.getElement(appendTo);
     const bodyChildren = target.children;
     for (const child of Array.from(bodyChildren)) {
-      if (child.id !== this.backdropId) {
+      const isPopperElement = child.hasAttribute('data-popper-placement');
+      if (child.id !== this.backdropId && !isPopperElement) {
         hide ? child.setAttribute('aria-hidden', '' + hide) : child.removeAttribute('aria-hidden');
       }
     }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12422 

Popper based components like Select or Dropdown get mounted to the DOM on the same level as Modal. Modal then on update can set aria-hidden label to true via function toggleSiblingsFromScreenReaders, which adds the label to all the elements that are siblings of the Modal, including these components.This causes the opened Popper based component to become invisible for screen readers and/or Playwright.

Fix this by excluding all the Popper components from this function's behaviour.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal accessibility to ensure Popper-managed content such as dropdowns and tooltips within modals remain properly accessible to screen readers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly-react/pull/12424)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->