### PR TITLE
feat(code-editor): add high contrast theme support

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps, ReactNode, useEffect, useRef, useState } from 'react';
+import { HTMLProps, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/CodeEditor/code-editor';
 import fileUploadStyles from '@patternfly/react-styles/css/components/FileUpload/file-upload';
@@ -157,6 +157,8 @@ export interface CodeEditorProps extends Omit<HTMLProps<HTMLDivElement>, 'onChan
   isCopyEnabled?: boolean;
   /** Flag indicating the editor is styled using monaco's dark theme. */
   isDarkTheme?: boolean;
+  /** Flag indicating the editor is styled using a high contrast theme. When combined with isDarkTheme, uses monaco's 'hc-black' theme; otherwise uses 'hc-light'. */
+  isHighContrast?: boolean;
   /** Flag that enables component to consume the available height of its container. If `height` prop is set to 100%, this will also become enabled. */
   isFullHeight?: boolean;
   /** Flag indicating the editor has a plain header. */
@@ -286,6 +288,7 @@ export const CodeEditor = ({
   height,
   isCopyEnabled = false,
   isDarkTheme = false,
+  isHighContrast = false,
   isDownloadEnabled = false,
   isFullHeight = false,
   isHeaderPlain = false,
@@ -462,6 +465,19 @@ export const CodeEditor = ({
     headerMainContent ||
     !!shortcutsPopoverProps.bodyContent;
 
+  const theme = useMemo(() => {
+    if (isDarkTheme && isHighContrast) {
+      return 'hc-black';
+    }
+    if (isHighContrast) {
+      return 'hc-light';
+    }
+    if (isDarkTheme) {
+      return 'pf-v6-theme-dark';
+    }
+    return 'pf-v6-theme-light';
+  }, [isDarkTheme, isHighContrast]);
+
   return (
     <Dropzone multiple={false} onDropAccepted={onDropAccepted} onDropRejected={onDropRejected}>
       {({ getRootProps, getInputProps, isDragActive, open }) => {
@@ -579,7 +595,7 @@ export const CodeEditor = ({
               onChange={onModelChange}
               onMount={editorDidMount}
               loading={loading}
-              theme={isDarkTheme ? 'pf-v6-theme-dark' : 'pf-v6-theme-light'}
+              theme={theme}
               {...editorProps}
               beforeMount={editorBeforeMount}
             />

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/CodeEditor.test.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/CodeEditor.test.tsx
@@ -2,7 +2,9 @@ import { render, screen, act } from '@testing-library/react';
 import { CodeEditor, Language } from '../CodeEditor';
 import styles from '@patternfly/react-styles/css/components/CodeEditor/code-editor';
 
-jest.mock('@monaco-editor/react', () => jest.fn(() => <div data-testid="mock-editor"></div>));
+jest.mock('@monaco-editor/react', () =>
+  jest.fn((props: any) => <div data-testid="mock-editor" data-theme={props.theme}></div>)
+);
 
 test('Matches snapshot without props', () => {
   const { asFragment } = render(<CodeEditor code="test" />);
@@ -71,4 +73,24 @@ test(`Renders with shortcuts when shortcutsPopoverButtonText is passed`, () => {
     screen.getByText('shortcuts-button').click();
   });
   expect(screen.getByText('shortcuts')).toBeInTheDocument();
+});
+
+test('Uses pf-v6-theme-light by default', () => {
+  render(<CodeEditor code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'pf-v6-theme-light');
+});
+
+test('Uses pf-v6-theme-dark when isDarkTheme is true', () => {
+  render(<CodeEditor isDarkTheme code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'pf-v6-theme-dark');
+});
+
+test('Uses hc-light when isHighContrast is true', () => {
+  render(<CodeEditor isHighContrast code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'hc-light');
+});
+
+test('Uses hc-black when both isHighContrast and isDarkTheme are true', () => {
+  render(<CodeEditor isHighContrast isDarkTheme code="test" />);
+  expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-theme', 'hc-black');
 });

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
         >
           <div
             data-testid="mock-editor"
+            data-theme="pf-v6-theme-light"
           />
         </div>
       </div>
@@ -196,6 +197,7 @@ exports[`Matches snapshot without props 1`] = `
       >
         <div
           data-testid="mock-editor"
+          data-theme="pf-v6-theme-light"
         />
       </div>
     </div>

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorBasic.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorBasic.tsx
@@ -4,12 +4,16 @@ import { Checkbox } from '@patternfly/react-core';
 
 export const CodeEditorBasic: React.FunctionComponent = () => {
   const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const [isHighContrast, setIsHighContrast] = useState(false);
   const [isLineNumbersVisible, setIsLineNumbersVisible] = useState(true);
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [isMinimapVisible, setIsMinimapVisible] = useState(false);
 
   const toggleDarkTheme = (checked) => {
     setIsDarkTheme(checked);
+  };
+  const toggleHighContrast = (checked) => {
+    setIsHighContrast(checked);
   };
 
   const toggleLineNumbers = (checked) => {
@@ -44,6 +48,14 @@ export const CodeEditorBasic: React.FunctionComponent = () => {
         name="toggle-theme"
       />
       <Checkbox
+        label="High contrast"
+        isChecked={isHighContrast}
+        onChange={(_event, checked) => toggleHighContrast(checked)}
+        aria-label="high contrast checkbox"
+        id="toggle-high-contrast"
+        name="toggle-high-contrast"
+      />
+      <Checkbox
         label="Line numbers"
         isChecked={isLineNumbersVisible}
         onChange={(_event, checked) => toggleLineNumbers(checked)}
@@ -69,6 +81,7 @@ export const CodeEditorBasic: React.FunctionComponent = () => {
       />
       <CodeEditor
         isDarkTheme={isDarkTheme}
+        isHighContrast={isHighContrast}
         isLineNumbersVisible={isLineNumbersVisible}
         isReadOnly={isReadOnly}
         isMinimapVisible={isMinimapVisible}

--- a/packages/react-integration/demo-app-ts/src/components/demos/CodeEditorDemo/CodeEditorDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/CodeEditorDemo/CodeEditorDemo.tsx
@@ -5,6 +5,7 @@ import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 
 interface CodeEditorDemoState {
   isDarkTheme: boolean;
+  isHighContrast: boolean;
   isLineNumbersVisible: boolean;
   isReadOnly: boolean;
   isMinimapVisible: boolean;
@@ -17,6 +18,7 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
     super(props);
     this.state = {
       isDarkTheme: false,
+      isHighContrast: false,
       isLineNumbersVisible: true,
       isReadOnly: false,
       isMinimapVisible: true,
@@ -27,6 +29,12 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
   toggleDarkTheme = (checked: boolean) => {
     this.setState({
       isDarkTheme: checked
+    });
+  };
+
+  toggleHighContrast = (checked: boolean) => {
+    this.setState({
+      isHighContrast: checked
     });
   };
 
@@ -70,7 +78,7 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
   };
 
   render() {
-    const { isDarkTheme, isLineNumbersVisible, isReadOnly, isMinimapVisible, code } = this.state;
+    const { isDarkTheme, isHighContrast, isLineNumbersVisible, isReadOnly, isMinimapVisible, code } = this.state;
 
     const customControl = (
       <CodeEditorControl
@@ -90,6 +98,14 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
           aria-label="dark theme checkbox"
           id="toggle-theme"
           name="toggle-theme"
+        />
+        <Checkbox
+          label="High contrast"
+          isChecked={isHighContrast}
+          onChange={(_event, checked) => this.toggleHighContrast(checked)}
+          aria-label="high contrast checkbox"
+          id="toggle-high-contrast"
+          name="toggle-high-contrast"
         />
         <Checkbox
           label="Line numbers"
@@ -120,6 +136,7 @@ export class CodeEditorDemo extends Component<CodeEditorProps, CodeEditorDemoSta
         </Button>
         <CodeEditor
           isDarkTheme={isDarkTheme}
+          isHighContrast={isHighContrast}
           isLineNumbersVisible={isLineNumbersVisible}
           isReadOnly={isReadOnly}
           isMinimapVisible={isMinimapVisible}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12383 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced high-contrast mode toggle for improved accessibility in the code editor.
  * CodeEditor now supports four distinct themes: light, dark, high-contrast light, and high-contrast dark modes.
  * High-contrast control integrated into editor examples and demo applications.

* **Tests**
  * Added tests to verify correct theme behavior across all mode combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly-react/pull/12430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->