### PR TITLE
fix: updated to do 6.6.0 prereleases.

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-charts",
-  "version": "8.5.1-prerelease.0",
+  "version": "8.6.0-prerelease.0",
   "description": "This library provides a set of React chart components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-code-editor/package.json
+++ b/packages/react-code-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-code-editor",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "This package provides a PatternFly wrapper for the Monaco code editor\n",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-core",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "This library provides a set of common React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@patternfly/react-docs",
   "description": "PatternFly React Docs",
-  "version": "7.5.1-prerelease.0",
+  "version": "7.6.0-prerelease.0",
   "publishConfig": {
     "access": "public",
     "tag": "prerelease"

--- a/packages/react-drag-drop/package.json
+++ b/packages/react-drag-drop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-drag-drop",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "PatternFly drag and drop solution",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-icons",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "PatternFly 4 Icons as React Components",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-styles",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-table",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "This library provides a set of React table components for use with the PatternFly 4",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-templates/package.json
+++ b/packages/react-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-templates",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "This package provides wrapped component demos for ease of use\n",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-tokens",
-  "version": "6.5.1-prerelease.0",
+  "version": "6.6.0-prerelease.0",
   "description": "This library provides access to the design tokens of PatternFly 4 from JavaScript",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Updated to setup for 6.6.0 prereleases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped prerelease versions across all library packages in the monorepo to reflect ongoing development progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/patternfly-react/pull/12434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->