### PR TITLE
fix(OutlinedCopy): Replace OutlinedCopy with RhUiCopyIcon

### DIFF
--- a/packages/react-core/src/components/Compass/examples/Compass.md
+++ b/packages/react-core/src/components/Compass/examples/Compass.md
@@ -18,7 +18,7 @@ propComponents:
 import { useRef, useState, useEffect } from 'react';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
-import OutlinedCopy from '@patternfly/react-icons/dist/esm/icons/outlined-copy-icon';
+import RhUiCopyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-copy-icon';
 import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 
 import './compass.css';

--- a/packages/react-core/src/components/Compass/examples/Compass.md
+++ b/packages/react-core/src/components/Compass/examples/Compass.md
@@ -16,10 +16,6 @@ propComponents:
 ---
 
 import { useRef, useState, useEffect } from 'react';
-import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
-import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
-import RhUiCopyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-copy-icon';
-import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 
 import './compass.css';
 

--- a/packages/react-core/src/demos/Compass/Compass.md
+++ b/packages/react-core/src/demos/Compass/Compass.md
@@ -6,7 +6,7 @@ section: components
 import { useRef, useState, useEffect } from 'react';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
-import OutlinedCopy from '@patternfly/react-icons/dist/esm/icons/outlined-copy-icon';
+import RhUiCopyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-copy-icon';
 import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';

--- a/packages/react-core/src/demos/Compass/examples/CompassDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDemo.tsx
@@ -30,7 +30,7 @@ import {
 } from '@patternfly/react-core';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import OutlinedPlusSquare from '@patternfly/react-icons/dist/esm/icons/outlined-plus-square-icon';
-import OutlinedCopy from '@patternfly/react-icons/dist/esm/icons/outlined-copy-icon';
+import RhUiCopyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-copy-icon';
 import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 
 export const CompassBasic: React.FunctionComponent = () => {
@@ -123,7 +123,7 @@ export const CompassBasic: React.FunctionComponent = () => {
             </ActionListGroup>
             <ActionListItem>
               <Tooltip content="Copy">
-                <Button isCircle variant="plain" icon={<OutlinedCopy />} aria-label="Copy" />
+                <Button isCircle variant="plain" icon={<RhUiCopyIcon />} aria-label="Copy" />
               </Tooltip>
             </ActionListItem>
             <ActionListGroup>
@@ -134,7 +134,7 @@ export const CompassBasic: React.FunctionComponent = () => {
               </ActionListItem>
               <ActionListItem>
                 <Tooltip content="Second copy">
-                  <Button isCircle variant="plain" icon={<OutlinedCopy />} aria-label="Copy2" />
+                  <Button isCircle variant="plain" icon={<RhUiCopyIcon />} aria-label="Copy2" />
                 </Tooltip>
               </ActionListItem>
             </ActionListGroup>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Compass example and demo documentation to use the new copy icon assets.
* **UI Improvements**
  * Replaced the “Copy” and “Second copy” sidebar action icons in the Compass demo with the updated icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->