### PR TITLE
fix(react-icons): move tslib to deps

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -31,14 +31,16 @@
     "generate": "rimraf dist/esm/icons dist/js/icons dist/static && yarn build:esm && node scripts/ensureEsmPackageJson.mjs && node scripts/writeIcons.mjs",
     "update-rhds-icons": "node scripts/parseRHIcons.mjs"
   },
+  "dependencies": {
+    "tslib": "^2.8.1"
+  },
   "devDependencies": {
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@patternfly/patternfly": "6.5.2",
     "@rhds/icons": "^2.2.0",
-    "fs-extra": "^11.3.3",
-    "tslib": "^2.8.1"
+    "fs-extra": "^11.3.3"
   },
   "peerDependencies": {
     "react": "^17 || ^18 || ^19",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

Fixes a runtime error when react-icons is used directly. This will match our other code packages which also have tslib as a dependency (core, charts, table, templates, code-editor). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies in the react-icons package to ensure required utilities are available during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->