### PR TITLE
fix(LinkIcon): Replace LinkIcon with RhUiLinkIcon

### DIFF
--- a/packages/react-core/src/components/Nav/examples/Nav.md
+++ b/packages/react-core/src/components/Nav/examples/Nav.md
@@ -14,7 +14,7 @@ import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
-import LinkIcon from '@patternfly/react-icons/dist/esm/icons/link-icon';
+import RhUiLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-link-icon';
 
 ## Examples
 

--- a/packages/react-core/src/components/Nav/examples/NavIcons.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavIcons.tsx
@@ -4,7 +4,7 @@ import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
-import LinkIcon from '@patternfly/react-icons/dist/esm/icons/link-icon';
+import RhUiLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-link-icon';
 
 export const NavIcons: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = useState(0);
@@ -52,7 +52,7 @@ export const NavIcons: React.FunctionComponent = () => {
           to="#nav-icon-link4"
           itemId={3}
           isActive={activeItem === 3}
-          icon={<LinkIcon />}
+          icon={<RhUiLinkIcon />}
         >
           Link 4
         </NavItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated navigation component example documentation to reflect revised icon usage in the Nav examples.
* **UI Updates**
  * Adjusted the navigation icons in example code to use the updated link icon component for the Link 4 item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->