### PR TITLE
fix(PendingIcon): Replace PendingIcon with RhUiPendingIcon

### DIFF
--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepper.md
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepper.md
@@ -7,7 +7,7 @@ propComponents: ['ProgressStepper', 'ProgressStep']
 
 import { Fragment, useState } from 'react';
 import RhUiInProgressIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-in-progress-icon';
-import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
+import RhUiPendingIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-pending-icon';
 
 ## Examples
 

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperCustomIcons.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperCustomIcons.tsx
@@ -1,6 +1,6 @@
 import { ProgressStepper, ProgressStep } from '@patternfly/react-core';
 import RhUiInProgressIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-in-progress-icon';
-import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
+import RhUiPendingIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-pending-icon';
 
 export const ProgressStepperCustomIcons: React.FunctionComponent = () => (
   <ProgressStepper aria-label="Progress stepper with custom icons">
@@ -23,7 +23,7 @@ export const ProgressStepperCustomIcons: React.FunctionComponent = () => (
     </ProgressStep>
     <ProgressStep
       variant="pending"
-      icon={<PendingIcon />}
+      icon={<RhUiPendingIcon />}
       id="custom-step3"
       titleId="custom-step3-title"
       aria-label="pending step"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ProgressStepper examples to use `RhUiPendingIcon` for the pending step icon instead of the previous pending icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->