### PR TITLE
fix(CalendarIcon): Replace CalendarIcon with RhUiCalendarFillIcon

### DIFF
--- a/packages/react-core/src/components/TextInput/examples/TextInput.md
+++ b/packages/react-core/src/components/TextInput/examples/TextInput.md
@@ -7,7 +7,7 @@ propComponents: ['TextInput', 'TextInputExpandedObj']
 ---
 
 import { useRef, useState } from 'react';
-import CalendarIcon from '@patternfly/react-icons/dist/esm/icons/calendar-icon';
+import RhUiCalendarFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-calendar-fill-icon';
 import ClockIcon from '@patternfly/react-icons/dist/esm/icons/clock-icon';
 
 ## Examples

--- a/packages/react-core/src/components/TextInput/examples/TextInputCustomIcon.tsx
+++ b/packages/react-core/src/components/TextInput/examples/TextInputCustomIcon.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { TextInput } from '@patternfly/react-core';
-import CalendarIcon from '@patternfly/react-icons/dist/esm/icons/calendar-icon';
+import RhUiCalendarFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-calendar-fill-icon';
 import ClockIcon from '@patternfly/react-icons/dist/esm/icons/clock-icon';
 
 export const TextInputCustomIcon: React.FunctionComponent = () => {
@@ -12,7 +12,7 @@ export const TextInputCustomIcon: React.FunctionComponent = () => {
       <TextInput
         value={calendar}
         type="text"
-        customIcon={<CalendarIcon />}
+        customIcon={<RhUiCalendarFillIcon />}
         onChange={(_event, value) => setCalendar(value)}
         aria-label="text input example with calendar icon"
       />

--- a/packages/react-core/src/components/TextInput/examples/TextInputCustomIconInvalid.tsx
+++ b/packages/react-core/src/components/TextInput/examples/TextInputCustomIconInvalid.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { TextInput, ValidatedOptions } from '@patternfly/react-core';
-import CalendarIcon from '@patternfly/react-icons/dist/esm/icons/calendar-icon';
+import RhUiCalendarFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-calendar-fill-icon';
 
 export const TextInputCustomIconInvalid: React.FunctionComponent = () => {
   const [calendar, setCalendar] = useState('');
@@ -11,7 +11,7 @@ export const TextInputCustomIconInvalid: React.FunctionComponent = () => {
         value={calendar}
         type="text"
         validated={ValidatedOptions.error}
-        customIcon={<CalendarIcon />}
+        customIcon={<RhUiCalendarFillIcon />}
         onChange={(_event, value) => setCalendar(value)}
         aria-label="text input example with calendar icon"
       />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated TextInput component examples to use an updated calendar icon implementation across custom icon and invalid state variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->