### PR TITLE
fix(GlobeIcon): Replace GlobeIcon with RhUiLanguageFillIcon

### DIFF
--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
@@ -21,8 +21,8 @@ import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import BookIcon from '@patternfly/react-icons/dist/esm/icons/book-icon';
 import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';
-import GlobeIcon from '@patternfly/react-icons/dist/esm/icons/globe-icon';
 import RhUiFlagFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-flag-fill-icon';
+import RhUiLanguageFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-language-fill-icon';
 
 ## Examples
 

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionListIconsOnTerms.tsx
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionListIconsOnTerms.tsx
@@ -9,8 +9,8 @@ import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import BookIcon from '@patternfly/react-icons/dist/esm/icons/book-icon';
 import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';
-import GlobeIcon from '@patternfly/react-icons/dist/esm/icons/globe-icon';
 import RhUiFlagFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-flag-fill-icon';
+import RhUiLanguageFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-language-fill-icon';
 
 export const DescriptionListIconsOnTerms: React.FunctionComponent = () => (
   <DescriptionList aria-label="With icons examples">
@@ -29,7 +29,7 @@ export const DescriptionListIconsOnTerms: React.FunctionComponent = () => (
       <DescriptionListDescription>example</DescriptionListDescription>
     </DescriptionListGroup>
     <DescriptionListGroup>
-      <DescriptionListTerm icon={<GlobeIcon />}>Pod selector</DescriptionListTerm>
+      <DescriptionListTerm icon={<RhUiLanguageFillIcon />}>Pod selector</DescriptionListTerm>
       <DescriptionListDescription>
         <Button variant="link" isInline icon={<RhUiAddCircleFillIcon />}>
           app=MyApp


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the icon used in DescriptionList component examples by switching from a globe icon to a language icon for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->