### PR TITLE
fix(MoonIcon): Replace MoonIcon with RhUiDarkModeFillIcon

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditor.md
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditor.md
@@ -12,7 +12,7 @@ import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import HashtagIcon from '@patternfly/react-icons/dist/esm/icons/hashtag-icon';
 import MapIcon from '@patternfly/react-icons/dist/esm/icons/map-icon';
-import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
+import RhUiDarkModeFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-dark-mode-fill-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import FontIcon from '@patternfly/react-icons/dist/esm/icons/font-icon';
 import AdjustIcon from '@patternfly/react-icons/dist/esm/icons/adjust-icon';

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorConfigurationModal.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorConfigurationModal.tsx
@@ -1,6 +1,6 @@
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import MapIcon from '@patternfly/react-icons/dist/esm/icons/map-icon';
-import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
+import RhUiDarkModeFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-dark-mode-fill-icon';
 import HashtagIcon from '@patternfly/react-icons/dist/esm/icons/hashtag-icon';
 import FontIcon from '@patternfly/react-icons/dist/esm/icons/font-icon';
 import AdjustIcon from '@patternfly/react-icons/dist/esm/icons/adjust-icon';
@@ -181,7 +181,7 @@ export const CodeEditorConfigurationModal: React.FunctionComponent = () => {
         description="Switch the editor to a dark color theme"
         isChecked={isDarkTheme}
         onChange={(_e, checked) => setIsDarkTheme(checked)}
-        icon={<MoonIcon />}
+        icon={<RhUiDarkModeFillIcon />}
       />
       <ConfigModalSwitch
         key="high-contrast-theme-switch"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark mode toggle icon across the code editor interface for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->