### PR TITLE
fix(EyeSlashIcon): Replace EyeSlashIcon with RhUiViewOffFillIcon

### DIFF
--- a/packages/react-core/src/components/LoginPage/LoginForm.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginForm.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '../Checkbox';
 import { ValidatedOptions } from '../../helpers/constants';
 import { InputGroup, InputGroupItem } from '../InputGroup';
 import RhUiViewFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-view-fill-icon';
-import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
+import RhUiViewOffFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-view-off-fill-icon';
 import { HelperText, HelperTextItem } from '../HelperText';
 
 export interface LoginFormProps extends Omit<React.HTMLProps<HTMLFormElement>, 'ref'> {
@@ -130,7 +130,7 @@ export const LoginForm: React.FunctionComponent<LoginFormProps> = ({
                 variant="control"
                 onClick={() => setPasswordHidden(!passwordHidden)}
                 aria-label={passwordHidden ? showPasswordAriaLabel : hidePasswordAriaLabel}
-                icon={passwordHidden ? <RhUiViewFillIcon /> : <EyeSlashIcon />}
+                icon={passwordHidden ? <RhUiViewFillIcon /> : <RhUiViewOffFillIcon />}
               />
             </InputGroupItem>
           </InputGroup>

--- a/packages/react-core/src/demos/PasswordGenerator/PasswordGenerator.md
+++ b/packages/react-core/src/demos/PasswordGenerator/PasswordGenerator.md
@@ -6,7 +6,7 @@ section: patterns
 import { useEffect, useRef, useState } from 'react';
 import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
 import RhUiViewFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-view-fill-icon';
-import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
+import RhUiViewOffFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-view-off-fill-icon';
 
 ## Demos
 

--- a/packages/react-core/src/demos/PasswordGenerator/examples/PasswordGenerator.tsx
+++ b/packages/react-core/src/demos/PasswordGenerator/examples/PasswordGenerator.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
 import RhUiViewFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-view-fill-icon';
-import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
+import RhUiViewOffFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-view-off-fill-icon';
 
 export const PasswordGenerator: React.FunctionComponent = () => {
   const generatePassword = () => {
@@ -123,7 +123,7 @@ export const PasswordGenerator: React.FunctionComponent = () => {
             variant="control"
             onClick={() => setPasswordHidden(!passwordHidden)}
             aria-label={passwordHidden ? 'Show password' : 'Hide password'}
-            icon={passwordHidden ? <RhUiViewFillIcon /> : <EyeSlashIcon />}
+            icon={passwordHidden ? <RhUiViewFillIcon /> : <RhUiViewOffFillIcon />}
           />
         </InputGroupItem>
       </InputGroup>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
This is one piece of https://github.com/patternfly/patternfly-react/issues/12400. Breaking it up by icon so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the password visibility toggle icon in the login form and password generator components for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->