### PR TITLE
fix(BoxIcon): Replace BoxIcon with RhUiContainerFillIcon

### DIFF
--- a/packages/react-core/src/components/Alert/examples/Alert.md
+++ b/packages/react-core/src/components/Alert/examples/Alert.md
@@ -9,7 +9,7 @@ ouia: true
 import './alert.css';
 import { Fragment, useEffect, useState } from 'react';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
-import BoxIcon from '@patternfly/react-icons/dist/esm/icons/box-icon';
+import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';

--- a/packages/react-core/src/components/Alert/examples/AlertCustomIcons.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertCustomIcons.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Alert } from '@patternfly/react-core';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
-import BoxIcon from '@patternfly/react-icons/dist/esm/icons/box-icon';
+import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
@@ -9,7 +9,7 @@ import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
 export const AlertCustomIcons: React.FunctionComponent = () => (
   <Fragment>
     <Alert customIcon={<RhUiUsersFillIcon />} title="Default alert title" />
-    <Alert customIcon={<BoxIcon />} variant="info" title="Info alert title" />
+    <Alert customIcon={<RhUiContainerFillIcon />} variant="info" title="Info alert title" />
     <Alert customIcon={<DatabaseIcon />} variant="success" title="Success alert title" />
     <Alert customIcon={<ServerIcon />} variant="warning" title="Warning alert title" />
     <Alert customIcon={<LaptopIcon />} variant="danger" title="Danger alert title" />

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -19,7 +19,7 @@ ouia: true
 
 import { createRef, Fragment, useEffect, useRef, useState } from 'react';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
-import BoxIcon from '@patternfly/react-icons/dist/esm/icons/box-icon';
+import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';

--- a/packages/react-core/src/components/Tabs/examples/TabsFilledWithIcons.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsFilledWithIcons.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Tabs, Tab, TabTitleText, TabTitleIcon, Checkbox } from '@patternfly/react-core';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
-import BoxIcon from '@patternfly/react-icons/dist/esm/icons/box-icon';
+import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 
 export const TabsFilledWithIcons: React.FunctionComponent = () => {
@@ -48,7 +48,7 @@ export const TabsFilledWithIcons: React.FunctionComponent = () => {
           title={
             <>
               <TabTitleIcon>
-                <BoxIcon />
+                <RhUiContainerFillIcon />
               </TabTitleIcon>{' '}
               <TabTitleText>Containers</TabTitleText>{' '}
             </>

--- a/packages/react-core/src/components/Tabs/examples/TabsIconAndText.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsIconAndText.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Tabs, Tab, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
-import BoxIcon from '@patternfly/react-icons/dist/esm/icons/box-icon';
+import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
@@ -43,7 +43,7 @@ export const TabsIconAndText: React.FunctionComponent = () => {
         title={
           <>
             <TabTitleIcon>
-              <BoxIcon />
+              <RhUiContainerFillIcon />
             </TabTitleIcon>{' '}
             <TabTitleText>Containers</TabTitleText>{' '}
           </>


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-react/issues/12401. Breaking into separate PRs so it is easier to review.

Made with [Cursor](https://cursor.com) and manually reviewed in site/checked output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Alert and Tabs component examples to use a different icon in relevant demonstrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->