### PR TITLE
fix(PficonSortCommonAscIcon): Replace PficonSortCommonAscIcon with RhUiSortDownSmallToLargeIcon

### DIFF
--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -20,7 +20,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 import { DragDropSort, DragDropContainer, Droppable as NewDroppable } from '@patternfly/react-drag-drop';

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -20,7 +20,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 import { DragDropSort, DragDropContainer, Droppable as NewDroppable } from '@patternfly/react-drag-drop';

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
@@ -25,7 +25,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 
@@ -155,7 +155,7 @@ export const DualListSelectorComplexOptionsActionsNext: React.FunctionComponent 
             aria-label="Sort Available"
             key="availableSortButton"
             isDisabled={isDisabled}
-            icon={<RhUiSortDownSmallToLargeIcon />}
+            icon={<RhMicronsSortDownSmallToLargeIcon />}
           />,
           <Dropdown
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
@@ -190,7 +190,7 @@ export const DualListSelectorComplexOptionsActionsNext: React.FunctionComponent 
             aria-label="Sort Chosen"
             key="chosenSortButton"
             isDisabled={isDisabled}
-            icon={<RhUiSortDownSmallToLargeIcon />}
+            icon={<RhMicronsSortDownSmallToLargeIcon />}
           />,
           <Dropdown
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
@@ -25,7 +25,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 
@@ -155,7 +155,7 @@ export const DualListSelectorComplexOptionsActionsNext: React.FunctionComponent 
             aria-label="Sort Available"
             key="availableSortButton"
             isDisabled={isDisabled}
-            icon={<PficonSortCommonAscIcon />}
+            icon={<RhUiSortDownSmallToLargeIcon />}
           />,
           <Dropdown
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
@@ -190,7 +190,7 @@ export const DualListSelectorComplexOptionsActionsNext: React.FunctionComponent 
             aria-label="Sort Chosen"
             key="chosenSortButton"
             isDisabled={isDisabled}
-            icon={<PficonSortCommonAscIcon />}
+            icon={<RhUiSortDownSmallToLargeIcon />}
           />,
           <Dropdown
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelector.md
@@ -33,7 +33,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 ## Examples

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelector.md
@@ -33,7 +33,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 ## Examples

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from 'react';
 import { Button, ButtonVariant, Checkbox } from '@patternfly/react-core';
 import { DualListSelector as DLSDeprecated } from '@patternfly/react-core/deprecated';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 
 export const DualListSelectorComplexOptionsActions: React.FunctionComponent = () => {
   const [availableOptions, setAvailableOptions] = useState<React.ReactNode[]>([
@@ -47,7 +47,7 @@ export const DualListSelectorComplexOptionsActions: React.FunctionComponent = ()
       aria-label="Sort available options"
       key="availableSortButton"
       isDisabled={isDisabled}
-      icon={<RhUiSortDownSmallToLargeIcon />}
+      icon={<RhMicronsSortDownSmallToLargeIcon />}
     />
   ];
 
@@ -58,7 +58,7 @@ export const DualListSelectorComplexOptionsActions: React.FunctionComponent = ()
       aria-label="Sort chosen options"
       key="chosenSortButton"
       isDisabled={isDisabled}
-      icon={<RhUiSortDownSmallToLargeIcon />}
+      icon={<RhMicronsSortDownSmallToLargeIcon />}
     />
   ];
 

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from 'react';
 import { Button, ButtonVariant, Checkbox } from '@patternfly/react-core';
 import { DualListSelector as DLSDeprecated } from '@patternfly/react-core/deprecated';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 
 export const DualListSelectorComplexOptionsActions: React.FunctionComponent = () => {
   const [availableOptions, setAvailableOptions] = useState<React.ReactNode[]>([
@@ -47,7 +47,7 @@ export const DualListSelectorComplexOptionsActions: React.FunctionComponent = ()
       aria-label="Sort available options"
       key="availableSortButton"
       isDisabled={isDisabled}
-      icon={<PficonSortCommonAscIcon />}
+      icon={<RhUiSortDownSmallToLargeIcon />}
     />
   ];
 
@@ -58,7 +58,7 @@ export const DualListSelectorComplexOptionsActions: React.FunctionComponent = ()
       aria-label="Sort chosen options"
       key="chosenSortButton"
       isDisabled={isDisabled}
-      icon={<PficonSortCommonAscIcon />}
+      icon={<RhUiSortDownSmallToLargeIcon />}
     />
   ];
 

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComposable.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComposable.tsx
@@ -21,7 +21,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 interface Option {
@@ -137,7 +137,7 @@ export const DualListSelectorComposable: React.FunctionComponent = () => {
         onClick={onSort}
         aria-label="Sort"
         key="sortButton"
-        icon={<RhUiSortDownSmallToLargeIcon />}
+        icon={<RhMicronsSortDownSmallToLargeIcon />}
       />
     );
   };

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComposable.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComposable.tsx
@@ -21,7 +21,7 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 interface Option {
@@ -137,7 +137,7 @@ export const DualListSelectorComposable: React.FunctionComponent = () => {
         onClick={onSort}
         aria-label="Sort"
         key="sortButton"
-        icon={<PficonSortCommonAscIcon />}
+        icon={<RhUiSortDownSmallToLargeIcon />}
       />
     );
   };

--- a/packages/react-drag-drop/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-drag-drop/src/components/DragDrop/examples/DragDrop.md
@@ -13,7 +13,6 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
 
 import { DragDropSort, DragDropContainer, Droppable as NewDroppable } from '@patternfly/react-drag-drop';
 

--- a/packages/react-drag-drop/src/components/DragDrop/examples/DragDropDemos.md
+++ b/packages/react-drag-drop/src/components/DragDrop/examples/DragDropDemos.md
@@ -12,7 +12,6 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
 
 import { DragDropSort, DragDropContainer, Droppable as NewDroppable } from '@patternfly/react-drag-drop';
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
@@ -25,8 +25,8 @@ import RhMicronsDoubleCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
 import RhUiSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-large-to-small-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 
@@ -133,7 +133,7 @@ export const DualListSelectorWithActionsDemo: React.FunctionComponent = () => {
         return direction === 'asc' ? 'ascending' : 'descending';
       },
       getIcon(direction: SortDirection) {
-        return direction === 'asc' ? <PficonSortCommonAscIcon /> : <RhUiSortDownLargeToSmallIcon />;
+        return direction === 'asc' ? <RhUiSortDownSmallToLargeIcon /> : <RhUiSortDownLargeToSmallIcon />;
       }
     };
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
@@ -26,7 +26,7 @@ import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-ico
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import RhUiSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-large-to-small-icon';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 
@@ -133,7 +133,7 @@ export const DualListSelectorWithActionsDemo: React.FunctionComponent = () => {
         return direction === 'asc' ? 'ascending' : 'descending';
       },
       getIcon(direction: SortDirection) {
-        return direction === 'asc' ? <RhUiSortDownSmallToLargeIcon /> : <RhUiSortDownLargeToSmallIcon />;
+        return direction === 'asc' ? <RhMicronsSortDownSmallToLargeIcon /> : <RhUiSortDownLargeToSmallIcon />;
       }
     };
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
@@ -5,8 +5,8 @@ import {
   DualListSelectorProps as DLSPropsDeprecated
 } from '@patternfly/react-core/deprecated';
 import RhUiSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-large-to-small-icon';
-import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
+import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
 
 interface DualListSelectorState {
   availableOptions: React.ReactNode[];
@@ -126,7 +126,7 @@ class DualListSelectorDeprecatedWithActionsDemo extends Component<DLSPropsDeprec
         onClick={() => this.onSort('available')}
         aria-label="Sort"
         key="availableSortButton"
-        icon={this.state.availableDescending ? <RhUiSortDownLargeToSmallIcon /> : <PficonSortCommonAscIcon />}
+        icon={this.state.availableDescending ? <RhUiSortDownLargeToSmallIcon /> : <RhUiSortDownSmallToLargeIcon />}
       />,
       <Dropdown
         key="availableDropdown"
@@ -153,7 +153,7 @@ class DualListSelectorDeprecatedWithActionsDemo extends Component<DLSPropsDeprec
         onClick={() => this.onSort('chosen')}
         aria-label="Sort"
         key="chosenSortButton"
-        icon={this.state.chosenDescending ? <RhUiSortDownLargeToSmallIcon /> : <PficonSortCommonAscIcon />}
+        icon={this.state.chosenDescending ? <RhUiSortDownLargeToSmallIcon /> :<RhUiSortDownSmallToLargeIcon />}
       />,
       <Dropdown
         isOpen={this.state.isChosenKebabOpen}

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
@@ -6,7 +6,7 @@ import {
 } from '@patternfly/react-core/deprecated';
 import RhUiSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-large-to-small-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import RhUiSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-small-to-large-icon';
+import RhMicronsSortDownSmallToLargeIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-small-to-large-icon';
 
 interface DualListSelectorState {
   availableOptions: React.ReactNode[];
@@ -126,7 +126,7 @@ class DualListSelectorDeprecatedWithActionsDemo extends Component<DLSPropsDeprec
         onClick={() => this.onSort('available')}
         aria-label="Sort"
         key="availableSortButton"
-        icon={this.state.availableDescending ? <RhUiSortDownLargeToSmallIcon /> : <RhUiSortDownSmallToLargeIcon />}
+        icon={this.state.availableDescending ? <RhUiSortDownLargeToSmallIcon /> : <RhMicronsSortDownSmallToLargeIcon />}
       />,
       <Dropdown
         key="availableDropdown"
@@ -153,7 +153,7 @@ class DualListSelectorDeprecatedWithActionsDemo extends Component<DLSPropsDeprec
         onClick={() => this.onSort('chosen')}
         aria-label="Sort"
         key="chosenSortButton"
-        icon={this.state.chosenDescending ? <RhUiSortDownLargeToSmallIcon /> :<RhUiSortDownSmallToLargeIcon />}
+        icon={this.state.chosenDescending ? <RhUiSortDownLargeToSmallIcon /> : <RhMicronsSortDownSmallToLargeIcon />}
       />,
       <Dropdown
         isOpen={this.state.isChosenKebabOpen}


### PR DESCRIPTION
First commit is RhUiSortDownSmallToLargeIcon but it looked weird in deprecated demos. Second commit is with Microns version.

Part of https://github.com/patternfly/patternfly-react/issues/12401. Breaking into separate PRs so it is easier to review.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the sort icons used in DualListSelector examples and demo applications to match current design standards, ensuring consistent visuals for both available and chosen lists (including deprecated variants).

* **Documentation**
  * Refreshed sort icon references in DualListSelector documentation pages for clearer, up-to-date example rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->