### PR TITLE
fix(PficonSortCommonDescIcon): Replace PficonSortCommonDescIcon with RhUiSortDownLargeToSmallIcon

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
@@ -26,7 +26,7 @@ import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-ico
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
-import PficonSortCommonDescIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-desc-icon';
+import RhUiSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-large-to-small-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
@@ -133,7 +133,7 @@ export const DualListSelectorWithActionsDemo: React.FunctionComponent = () => {
         return direction === 'asc' ? 'ascending' : 'descending';
       },
       getIcon(direction: SortDirection) {
-        return direction === 'asc' ? <PficonSortCommonAscIcon /> : <PficonSortCommonDescIcon />;
+        return direction === 'asc' ? <PficonSortCommonAscIcon /> : <RhUiSortDownLargeToSmallIcon />;
       }
     };
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
@@ -4,7 +4,7 @@ import {
   DualListSelector as DLSDeprecated,
   DualListSelectorProps as DLSPropsDeprecated
 } from '@patternfly/react-core/deprecated';
-import PficonSortCommonDescIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-desc-icon';
+import RhUiSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-sort-down-large-to-small-icon';
 import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pficon-sort-common-asc-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
@@ -126,7 +126,7 @@ class DualListSelectorDeprecatedWithActionsDemo extends Component<DLSPropsDeprec
         onClick={() => this.onSort('available')}
         aria-label="Sort"
         key="availableSortButton"
-        icon={this.state.availableDescending ? <PficonSortCommonDescIcon /> : <PficonSortCommonAscIcon />}
+        icon={this.state.availableDescending ? <RhUiSortDownLargeToSmallIcon /> : <PficonSortCommonAscIcon />}
       />,
       <Dropdown
         key="availableDropdown"
@@ -153,7 +153,7 @@ class DualListSelectorDeprecatedWithActionsDemo extends Component<DLSPropsDeprec
         onClick={() => this.onSort('chosen')}
         aria-label="Sort"
         key="chosenSortButton"
-        icon={this.state.chosenDescending ? <PficonSortCommonDescIcon /> : <PficonSortCommonAscIcon />}
+        icon={this.state.chosenDescending ? <RhUiSortDownLargeToSmallIcon /> : <PficonSortCommonAscIcon />}
       />,
       <Dropdown
         isOpen={this.state.isChosenKebabOpen}


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-react/issues/12401. Breaking into separate PRs so it is easier to review.

Made with [Cursor](https://cursor.com)