### PR TITLE
fix(CodeIcon): Replace CodeIcon with RhUiCodeIcon

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -19,7 +19,7 @@ import type { editor } from 'monaco-editor';
 import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import Dropzone, { FileRejection } from 'react-dropzone';
 import { CodeEditorContext } from './CodeEditorUtils';
@@ -480,7 +480,12 @@ export const CodeEditor = ({
         const editorEmptyState =
           emptyState ||
           (isUploadEnabled ? (
-            <EmptyState variant={EmptyStateVariant.sm} titleText={emptyStateTitle} icon={CodeIcon} headingLevel="h4">
+            <EmptyState
+              variant={EmptyStateVariant.sm}
+              titleText={emptyStateTitle}
+              icon={RhUiCodeIcon}
+              headingLevel="h4"
+            >
               <EmptyStateBody>{emptyStateBody}</EmptyStateBody>
               {!isReadOnly && (
                 <EmptyStateFooter>
@@ -498,7 +503,12 @@ export const CodeEditor = ({
               )}
             </EmptyState>
           ) : (
-            <EmptyState variant={EmptyStateVariant.sm} titleText={emptyStateTitle} icon={CodeIcon} headingLevel="h4">
+            <EmptyState
+              variant={EmptyStateVariant.sm}
+              titleText={emptyStateTitle}
+              icon={RhUiCodeIcon}
+              headingLevel="h4"
+            >
               {!isReadOnly && (
                 <EmptyStateFooter>
                   <EmptyStateActions>
@@ -569,7 +579,7 @@ export const CodeEditor = ({
             {isLanguageLabelVisible && (
               <div className={css(styles.codeEditorTab)}>
                 <span className={css(styles.codeEditorTabIcon)}>
-                  <CodeIcon />
+                  <RhUiCodeIcon />
                 </span>
                 <span className={css(styles.codeEditorTabText)}>{language.toUpperCase()}</span>
               </div>

--- a/packages/react-core/src/demos/Compass/Compass.md
+++ b/packages/react-core/src/demos/Compass/Compass.md
@@ -12,7 +12,7 @@ import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import imgAvatar from '../assets/avatarImg.svg';
 import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -32,7 +32,7 @@ import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import pfLogo from '../../assets/PF-IconLogo-color.svg';
 import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';
@@ -294,7 +294,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                       to="#nav-icon-link4"
                       itemId={3}
                       isActive={activeItem === 3}
-                      icon={<CodeIcon />}
+                      icon={<RhUiCodeIcon />}
                       anchorRef={navItem4Ref}
                       aria-label="Network services"
                     >

--- a/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
@@ -25,7 +25,7 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
@@ -106,7 +106,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                             </FlexItem>
                             <FlexItem>
                               <Icon>
-                                <CodeIcon />
+                                <RhUiCodeIcon />
                               </Icon>
                               4 <span className="pf-v6-screen-reader">Code blocks</span>
                             </FlexItem>
@@ -157,7 +157,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                             </FlexItem>
                             <FlexItem>
                               <Icon>
-                                <CodeIcon />
+                                <RhUiCodeIcon />
                               </Icon>
                               9 <span className="pf-v6-screen-reader">Code blocks</span>
                             </FlexItem>
@@ -256,7 +256,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                             </FlexItem>
                             <FlexItem>
                               <Icon>
-                                <CodeIcon />
+                                <RhUiCodeIcon />
                               </Icon>
                               4 <span className="pf-v6-screen-reader">Code blocks</span>
                             </FlexItem>
@@ -307,7 +307,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                             </FlexItem>
                             <FlexItem>
                               <Icon>
-                                <CodeIcon />
+                                <RhUiCodeIcon />
                               </Icon>
                               9 <span className="pf-v6-screen-reader">Code blocks</span>
                             </FlexItem>

--- a/packages/react-core/src/demos/DataList/examples/DataListStaticBottomPagination.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListStaticBottomPagination.tsx
@@ -27,7 +27,7 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { rows } from '@patternfly/react-core/dist/esm/demos/sampleData';
 
@@ -162,7 +162,7 @@ export const DataListStaticBottomPagination: React.FunctionComponent = () => {
                             <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                               <FlexItem>
                                 <Icon>
-                                  <CodeIcon />
+                                  <RhUiCodeIcon />
                                 </Icon>{' '}
                                 {applications}
                                 <span className="pf-v6-screen-reader">Code blocks</span>

--- a/packages/react-core/src/demos/DataListDemo.md
+++ b/packages/react-core/src/demos/DataListDemo.md
@@ -11,7 +11,7 @@ import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-m
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import { css } from '@patternfly/react-styles';
 
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';

--- a/packages/react-core/src/demos/Nav.md
+++ b/packages/react-core/src/demos/Nav.md
@@ -15,7 +15,7 @@ import pfLogo from '@patternfly/react-core/src/demos/assets/PF-HorizontalLogo-Co
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';

--- a/packages/react-core/src/demos/Page.md
+++ b/packages/react-core/src/demos/Page.md
@@ -15,7 +15,6 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import pfLogo from '@patternfly/react-core/src/demos/assets/PF-HorizontalLogo-Color.svg';
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';
 

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -6,7 +6,7 @@ section: patterns
 import { Fragment, useState } from 'react';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';

--- a/packages/react-core/src/demos/Tabs.md
+++ b/packages/react-core/src/demos/Tabs.md
@@ -6,7 +6,7 @@ section: components
 import { Fragment, useCallback, useRef, useState } from 'react';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiInformationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-information-fill-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -34,7 +34,7 @@ import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/ico
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';
@@ -313,7 +313,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
                     to="#nav-link4"
                     itemId={3}
                     isActive={activeItem === 3}
-                    icon={<CodeIcon />}
+                    icon={<RhUiCodeIcon />}
                     anchorRef={navItem4Ref}
                     aria-label="Network services"
                   >

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
@@ -40,7 +40,7 @@ import {
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -234,7 +234,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -277,7 +277,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -331,7 +331,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -374,7 +374,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
@@ -40,7 +40,7 @@ import {
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -234,7 +234,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -277,7 +277,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -331,7 +331,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -374,7 +374,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
@@ -40,7 +40,7 @@ import {
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -234,7 +234,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -277,7 +277,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -331,7 +331,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5
@@ -374,7 +374,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                         <CodeBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
-                        <CodeIcon /> 4
+                        <RhUiCodeIcon /> 4
                       </FlexItem>
                       <FlexItem>
                         <CubeIcon /> 5

--- a/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
@@ -49,7 +49,7 @@ import {
   CustomActionsToggleProps
 } from '@patternfly/react-table';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
@@ -265,7 +265,7 @@ export const TablesAndTabs = () => {
               <Flex>
                 <FlexItem>{repo.prs}</FlexItem>
                 <FlexItem>
-                  <CodeIcon key="icon" />
+                  <RhUiCodeIcon key="icon" />
                 </FlexItem>
               </Flex>
             </Td>

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
@@ -27,7 +27,7 @@ import {
   Checkbox
 } from '@patternfly/react-core';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import t_global_color_brand_default from '@patternfly/react-tokens/dist/esm/t_global_color_brand_default';
 
@@ -807,7 +807,7 @@ export const TableComposableDemo = () => {
       } else if (index === 2) {
         return (
           <>
-            <CodeIcon key="icon" /> {cell}
+            <RhUiCodeIcon key="icon" /> {cell}
           </>
         );
       } else if (index === 3) {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
@@ -3,7 +3,7 @@ import { compoundExpand, IRow, ICell, IRowCell } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
@@ -51,7 +51,7 @@ export class TableCompoundExpandableDemo extends Component<TableProps, TableStat
             {
               title: (
                 <>
-                  <CodeIcon key="icon" /> 4
+                  <RhUiCodeIcon key="icon" /> 4
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-2' }
@@ -128,7 +128,7 @@ export class TableCompoundExpandableDemo extends Component<TableProps, TableStat
             {
               title: (
                 <>
-                  <CodeIcon key="icon" /> 4
+                  <RhUiCodeIcon key="icon" /> 4
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-5' }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
@@ -3,7 +3,7 @@ import { compoundExpand, IRow, ICell, IRowCell } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
@@ -51,7 +51,7 @@ export class TableEditableCompoundExpandableDemo extends Component<TableProps, T
             {
               title: (
                 <>
-                  <CodeIcon key="icon" /> 4
+                  <RhUiCodeIcon key="icon" /> 4
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-2' }
@@ -128,7 +128,7 @@ export class TableEditableCompoundExpandableDemo extends Component<TableProps, T
             {
               title: (
                 <>
-                  <CodeIcon key="icon" /> 4
+                  <RhUiCodeIcon key="icon" /> 4
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-5' }

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -44,7 +44,7 @@ The documentation for the deprecated table implementation can be found under the
 import { Fragment, isValidElement, useCallback, useEffect, useRef, useState, useLayoutEffect } from 'react';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';

--- a/packages/react-table/src/components/Table/examples/TableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableCompoundExpandable.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td, TdProps, ExpandableRowContent } from '@patternfly/react-table';
 
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 interface Repository {
@@ -90,7 +90,7 @@ export const TableCompoundExpandable: React.FunctionComponent = () => {
                 dataLabel={columnNames.prs}
                 compoundExpand={compoundExpandParams(repo, 'prs', rowIndex, 2)}
               >
-                <CodeIcon key="icon" /> {repo.prs}
+                <RhUiCodeIcon key="icon" /> {repo.prs}
               </Td>
               <Td
                 width={10}

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -50,7 +50,7 @@ ModalFooter,
 import { DragDropSort } from '@patternfly/react-drag-drop';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';

--- a/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
+++ b/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
@@ -17,7 +17,7 @@ import {
   PaginationVariant
 } from '@patternfly/react-core';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { DashboardWrapper } from '@patternfly/react-table/dist/esm/demos/DashboardWrapper';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
@@ -234,7 +234,7 @@ export const TableCompoundExpansion: React.FunctionComponent = () => {
                   <Td dataLabel={columnNames.prs} compoundExpand={compoundExpandParams(repo, 'prs', rowIndex, 2)}>
                     <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                       <FlexItem>
-                        <CodeIcon key="icon" />
+                        <RhUiCodeIcon key="icon" />
                       </FlexItem>
                       <FlexItem>{repo.prs}</FlexItem>
                     </Flex>{' '}

--- a/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
+++ b/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
@@ -32,7 +32,7 @@ import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
 import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
 import SyncIcon from '@patternfly/react-icons/dist/esm/icons/sync-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
@@ -285,7 +285,7 @@ export const TableSortableResponsive: React.FunctionComponent = () => {
                     <Td dataLabel={columns[2]} width={10}>
                       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                         <FlexItem>
-                          <CodeIcon key="icon" />
+                          <RhUiCodeIcon key="icon" />
                         </FlexItem>
                         <FlexItem>{row.applications}</FlexItem>
                       </Flex>

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableCompoundExpandable.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableCompoundExpandable.tsx
@@ -3,7 +3,7 @@ import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-tab
 import { compoundExpand } from '@patternfly/react-table';
 
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
@@ -87,7 +87,7 @@ export const LegacyTableCompoundExpandable: React.FunctionComponent = () => {
         {
           title: (
             <Fragment>
-              <CodeIcon key="icon" /> {repo.prs}
+              <RhUiCodeIcon key="icon" /> {repo.prs}
             </Fragment>
           ),
           props: {

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -16,7 +16,7 @@ This deprecated `Table` component is configuration-based and takes a less declar
 import { Fragment, isValidElement, useCallback, useEffect, useRef, useState } from 'react';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
-import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';


### PR DESCRIPTION
I think we want a microns version but it doesn't exist.

Part of https://github.com/patternfly/patternfly-react/issues/12401. Breaking into separate PRs so it is easier to review.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated icon designs across various components, including data lists, navigation, tables, and editors, for improved visual consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->