### PR TITLE
fix(CodeBranchIcon): Replace CodeBranchIcon with RhUiBranchIcon

### DIFF
--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -19,7 +19,7 @@ propComponents:
 ---
 
 import { Fragment, useState } from 'react';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -19,7 +19,7 @@ propComponents:
 ---
 
 import { Fragment, useState } from 'react';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';

--- a/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
@@ -15,7 +15,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 
 export const DataListExpandable: React.FunctionComponent = () => {
   const [isOpen1, setIsOpen1] = useState(false);
@@ -66,7 +66,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <RhUiBranchIcon />
+                  <RhUiBranchFillIcon />
                 </DataListCell>,
                 <DataListCell key="primary content">
                   <div id="ex-item1">Primary content</div>
@@ -137,7 +137,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <RhUiBranchIcon />
+                  <RhUiBranchFillIcon />
                 </DataListCell>,
                 <DataListCell key="secondary content">
                   <div id="ex-item2">Secondary content</div>
@@ -207,7 +207,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <RhUiBranchIcon />
+                  <RhUiBranchFillIcon />
                 </DataListCell>,
                 <DataListCell key="tertiary content">
                   <div id="ex-item3">Tertiary content</div>

--- a/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
@@ -15,7 +15,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 
 export const DataListExpandable: React.FunctionComponent = () => {
   const [isOpen1, setIsOpen1] = useState(false);
@@ -66,7 +66,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <CodeBranchIcon />
+                  <RhUiBranchIcon />
                 </DataListCell>,
                 <DataListCell key="primary content">
                   <div id="ex-item1">Primary content</div>
@@ -137,7 +137,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <CodeBranchIcon />
+                  <RhUiBranchIcon />
                 </DataListCell>,
                 <DataListCell key="secondary content">
                   <div id="ex-item2">Secondary content</div>
@@ -207,7 +207,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <CodeBranchIcon />
+                  <RhUiBranchIcon />
                 </DataListCell>,
                 <DataListCell key="tertiary content">
                   <div id="ex-item3">Tertiary content</div>

--- a/packages/react-core/src/components/DataList/examples/DataListMixedExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListMixedExpandable.tsx
@@ -15,7 +15,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 
 export const DataListMixedExpandable: React.FunctionComponent = () => {
   const [isOpen1, setIsOpen1] = useState(false);
@@ -68,7 +68,7 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <RhUiBranchIcon />
+                  <RhUiBranchFillIcon />
                 </DataListCell>,
                 <DataListCell key="primary content">
                   <div id="m-ex-item1">Primary content</div>
@@ -141,7 +141,7 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <RhUiBranchIcon />
+                  <RhUiBranchFillIcon />
                 </DataListCell>,
                 <DataListCell key="secondary content">
                   <div id="m-ex-item2">Secondary content</div>
@@ -201,7 +201,7 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <RhUiBranchIcon />
+                  <RhUiBranchFillIcon />
                 </DataListCell>,
                 <DataListCell key="tertiary content">
                   <div id="m-ex-item3">Tertiary content</div>

--- a/packages/react-core/src/components/DataList/examples/DataListMixedExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListMixedExpandable.tsx
@@ -15,7 +15,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 
 export const DataListMixedExpandable: React.FunctionComponent = () => {
   const [isOpen1, setIsOpen1] = useState(false);
@@ -68,7 +68,7 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <CodeBranchIcon />
+                  <RhUiBranchIcon />
                 </DataListCell>,
                 <DataListCell key="primary content">
                   <div id="m-ex-item1">Primary content</div>
@@ -141,7 +141,7 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <CodeBranchIcon />
+                  <RhUiBranchIcon />
                 </DataListCell>,
                 <DataListCell key="secondary content">
                   <div id="m-ex-item2">Secondary content</div>
@@ -201,7 +201,7 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
             <DataListItemCells
               dataListCells={[
                 <DataListCell isIcon key="icon">
-                  <CodeBranchIcon />
+                  <RhUiBranchIcon />
                 </DataListCell>,
                 <DataListCell key="tertiary content">
                   <div id="m-ex-item3">Tertiary content</div>

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -23,7 +23,7 @@ ouia: true
 import { Fragment, createRef, useEffect, useRef, useState } from 'react';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiTableIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-table-icon';

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -23,7 +23,7 @@ ouia: true
 import { Fragment, createRef, useEffect, useRef, useState } from 'react';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiTableIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-table-icon';

--- a/packages/react-core/src/components/Menu/examples/MenuWithActions.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithActions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Menu, MenuContent, MenuGroup, MenuList, MenuItem, MenuItemAction } from '@patternfly/react-core';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 
 export const MenuWithActions: React.FunctionComponent = () => {
@@ -31,7 +31,7 @@ export const MenuWithActions: React.FunctionComponent = () => {
               isSelected={selectedItems.indexOf(0) !== -1}
               actions={
                 <MenuItemAction
-                  icon={<RhUiBranchIcon />}
+                  icon={<RhUiBranchFillIcon />}
                   actionId="code"
                   // eslint-disable-next-line no-console
                   onClick={() => console.log('clicked on code icon')}

--- a/packages/react-core/src/components/Menu/examples/MenuWithActions.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithActions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Menu, MenuContent, MenuGroup, MenuList, MenuItem, MenuItemAction } from '@patternfly/react-core';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 
 export const MenuWithActions: React.FunctionComponent = () => {
@@ -31,7 +31,7 @@ export const MenuWithActions: React.FunctionComponent = () => {
               isSelected={selectedItems.indexOf(0) !== -1}
               actions={
                 <MenuItemAction
-                  icon={<CodeBranchIcon />}
+                  icon={<RhUiBranchIcon />}
                   actionId="code"
                   // eslint-disable-next-line no-console
                   onClick={() => console.log('clicked on code icon')}

--- a/packages/react-core/src/components/Menu/examples/MenuWithDescription.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDescription.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 
 export const MenuWithDescription: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = useState(0);
@@ -15,14 +15,14 @@ export const MenuWithDescription: React.FunctionComponent = () => {
     <Menu onSelect={onSelect} activeItemId={activeItem}>
       <MenuContent>
         <MenuList>
-          <MenuItem icon={<CodeBranchIcon />} description="Description" itemId={0}>
+          <MenuItem icon={<RhUiBranchIcon />} description="Description" itemId={0}>
             Action 1
           </MenuItem>
-          <MenuItem isDisabled icon={<CodeBranchIcon />} description="Description" itemId={1}>
+          <MenuItem isDisabled icon={<RhUiBranchIcon />} description="Description" itemId={1}>
             Action 2 disabled
           </MenuItem>
           <MenuItem
-            icon={<CodeBranchIcon />}
+            icon={<RhUiBranchIcon />}
             description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
             itemId={2}
           >

--- a/packages/react-core/src/components/Menu/examples/MenuWithDescription.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDescription.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 
 export const MenuWithDescription: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = useState(0);
@@ -15,14 +15,14 @@ export const MenuWithDescription: React.FunctionComponent = () => {
     <Menu onSelect={onSelect} activeItemId={activeItem}>
       <MenuContent>
         <MenuList>
-          <MenuItem icon={<RhUiBranchIcon />} description="Description" itemId={0}>
+          <MenuItem icon={<RhUiBranchFillIcon />} description="Description" itemId={0}>
             Action 1
           </MenuItem>
-          <MenuItem isDisabled icon={<RhUiBranchIcon />} description="Description" itemId={1}>
+          <MenuItem isDisabled icon={<RhUiBranchFillIcon />} description="Description" itemId={1}>
             Action 2 disabled
           </MenuItem>
           <MenuItem
-            icon={<RhUiBranchIcon />}
+            icon={<RhUiBranchFillIcon />}
             description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
             itemId={2}
           >

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldown.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldown.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -161,7 +161,7 @@ export const MenuWithDrilldown: React.FunctionComponent = () => {
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<CodeBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
                   From git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldown.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldown.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -161,7 +161,7 @@ export const MenuWithDrilldown: React.FunctionComponent = () => {
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -20,7 +20,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
@@ -440,7 +440,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
               onClick={() => setBreadcrumb(addStorageBreadcrumb)}
               drilldownMenu={
                 <DrilldownMenu id="breadcrumbs-drilldownMenuStorage">
-                  <MenuItem icon={<CodeBranchIcon />} itemId="git">
+                  <MenuItem icon={<RhUiBranchIcon />} itemId="git">
                     From git
                   </MenuItem>
                   <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -20,7 +20,7 @@ import {
   MenuToggleElement
 } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
@@ -440,7 +440,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
               onClick={() => setBreadcrumb(addStorageBreadcrumb)}
               drilldownMenu={
                 <DrilldownMenu id="breadcrumbs-drilldownMenuStorage">
-                  <MenuItem icon={<RhUiBranchIcon />} itemId="git">
+                  <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                     From git
                   </MenuItem>
                   <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -164,7 +164,7 @@ export const MenuDrilldownInitialState: React.FunctionComponent = () => {
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -164,7 +164,7 @@ export const MenuDrilldownInitialState: React.FunctionComponent = () => {
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<CodeBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
                   From git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownSubmenuFunctions.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownSubmenuFunctions.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -161,7 +161,7 @@ export const MenuWithDrilldownSubmenuFunctions: React.FunctionComponent = () => 
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownSubmenuFunctions.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownSubmenuFunctions.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -161,7 +161,7 @@ export const MenuWithDrilldownSubmenuFunctions: React.FunctionComponent = () => 
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<CodeBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
                   From git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/components/Menu/examples/MenuWithIcons.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithIcons.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -17,7 +17,7 @@ export const MenuWithIcons: React.FunctionComponent = () => {
     <Menu onSelect={onSelect} activeItemId={activeItem}>
       <MenuContent>
         <MenuList>
-          <MenuItem icon={<RhUiBranchIcon />} itemId={0}>
+          <MenuItem icon={<RhUiBranchFillIcon />} itemId={0}>
             From git
           </MenuItem>
           <MenuItem icon={<LayerGroupIcon />} itemId={1}>

--- a/packages/react-core/src/components/Menu/examples/MenuWithIcons.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithIcons.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -17,7 +17,7 @@ export const MenuWithIcons: React.FunctionComponent = () => {
     <Menu onSelect={onSelect} activeItemId={activeItem}>
       <MenuContent>
         <MenuList>
-          <MenuItem icon={<CodeBranchIcon />} itemId={0}>
+          <MenuItem icon={<RhUiBranchIcon />} itemId={0}>
             From git
           </MenuItem>
           <MenuItem icon={<LayerGroupIcon />} itemId={1}>

--- a/packages/react-core/src/demos/CustomMenus/CustomMenus.md
+++ b/packages/react-core/src/demos/CustomMenus/CustomMenus.md
@@ -8,7 +8,7 @@ import { cloneElement, Fragment, useEffect, useRef, useState } from 'react';
 
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';

--- a/packages/react-core/src/demos/CustomMenus/CustomMenus.md
+++ b/packages/react-core/src/demos/CustomMenus/CustomMenus.md
@@ -8,7 +8,7 @@ import { cloneElement, Fragment, useEffect, useRef, useState } from 'react';
 
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';

--- a/packages/react-core/src/demos/CustomMenus/examples/ActionsMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/ActionsMenuDemo.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { MenuToggle, MenuItemAction, Select, SelectGroup, SelectList, SelectOption } from '@patternfly/react-core';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 
 export const ActionsMenuDemo: React.FunctionComponent = () => {
@@ -46,7 +46,7 @@ export const ActionsMenuDemo: React.FunctionComponent = () => {
             isSelected={selectedItems.includes(0)}
             actions={
               <MenuItemAction
-                icon={<RhUiBranchIcon />}
+                icon={<RhUiBranchFillIcon />}
                 actionId="code"
                 // eslint-disable-next-line no-console
                 onClick={() => console.log('clicked on code icon')}

--- a/packages/react-core/src/demos/CustomMenus/examples/ActionsMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/ActionsMenuDemo.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { MenuToggle, MenuItemAction, Select, SelectGroup, SelectList, SelectOption } from '@patternfly/react-core';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 
 export const ActionsMenuDemo: React.FunctionComponent = () => {
@@ -46,7 +46,7 @@ export const ActionsMenuDemo: React.FunctionComponent = () => {
             isSelected={selectedItems.includes(0)}
             actions={
               <MenuItemAction
-                icon={<CodeBranchIcon />}
+                icon={<RhUiBranchIcon />}
                 actionId="code"
                 // eslint-disable-next-line no-console
                 onClick={() => console.log('clicked on code icon')}

--- a/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
@@ -10,7 +10,7 @@ import {
   MenuContainer
 } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -191,7 +191,7 @@ export const DrilldownMenuDemo: React.FunctionComponent = () => {
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From Git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
@@ -10,7 +10,7 @@ import {
   MenuContainer
 } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -191,7 +191,7 @@ export const DrilldownMenuDemo: React.FunctionComponent = () => {
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
-                <MenuItem icon={<CodeBranchIcon />} itemId="git">
+                <MenuItem icon={<RhUiBranchIcon />} itemId="git">
                   From Git
                 </MenuItem>
                 <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
@@ -24,8 +24,8 @@ import {
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
@@ -104,7 +104,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <CodeBranchIcon />
+                                <RhUiBranchIcon />
                               </Icon>
                               10 <span className="pf-v6-screen-reader">Branches</span>
                             </FlexItem>
@@ -155,7 +155,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <CodeBranchIcon />
+                                <RhUiBranchIcon />
                               </Icon>
                               5 <span className="pf-v6-screen-reader">Branches</span>
                             </FlexItem>
@@ -253,7 +253,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <CodeBranchIcon />
+                                <RhUiBranchIcon />
                               </Icon>
                               10
                               <span className="pf-v6-screen-reader">Branches</span>
@@ -305,7 +305,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <CodeBranchIcon />
+                                <RhUiBranchIcon />
                               </Icon>
                               5 <span className="pf-v6-screen-reader">Branches</span>
                             </FlexItem>

--- a/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
@@ -25,7 +25,7 @@ import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
@@ -104,7 +104,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <RhUiBranchIcon />
+                                <RhUiBranchFillIcon />
                               </Icon>
                               10 <span className="pf-v6-screen-reader">Branches</span>
                             </FlexItem>
@@ -155,7 +155,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <RhUiBranchIcon />
+                                <RhUiBranchFillIcon />
                               </Icon>
                               5 <span className="pf-v6-screen-reader">Branches</span>
                             </FlexItem>
@@ -253,7 +253,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <RhUiBranchIcon />
+                                <RhUiBranchFillIcon />
                               </Icon>
                               10
                               <span className="pf-v6-screen-reader">Branches</span>
@@ -305,7 +305,7 @@ export const DataListBasic: React.FunctionComponent = () => {
                           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                             <FlexItem>
                               <Icon>
-                                <RhUiBranchIcon />
+                                <RhUiBranchFillIcon />
                               </Icon>
                               5 <span className="pf-v6-screen-reader">Branches</span>
                             </FlexItem>

--- a/packages/react-core/src/demos/DataList/examples/DataListExpandableControlInToolbar.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListExpandableControlInToolbar.tsx
@@ -28,7 +28,7 @@ import {
 
 import { DashboardWrapper } from '@patternfly/react-core/src/demos/DashboardWrapper';
 
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 
@@ -160,7 +160,7 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell isIcon key="icon">
-                      <RhUiBranchIcon />
+                      <RhUiBranchFillIcon />
                     </DataListCell>,
                     <DataListCell key="primary content">
                       <div id="ex-item1">Primary content</div>
@@ -237,7 +237,7 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell isIcon key="icon">
-                      <RhUiBranchIcon />
+                      <RhUiBranchFillIcon />
                     </DataListCell>,
                     <DataListCell key="secondary content">
                       <div id="ex-item2">Secondary content</div>
@@ -313,7 +313,7 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell isIcon key="icon">
-                      <RhUiBranchIcon />
+                      <RhUiBranchFillIcon />
                     </DataListCell>,
                     <DataListCell key="tertiary content">
                       <div id="ex-item3">Tertiary content</div>

--- a/packages/react-core/src/demos/DataList/examples/DataListExpandableControlInToolbar.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListExpandableControlInToolbar.tsx
@@ -28,7 +28,7 @@ import {
 
 import { DashboardWrapper } from '@patternfly/react-core/src/demos/DashboardWrapper';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 
@@ -160,7 +160,7 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell isIcon key="icon">
-                      <CodeBranchIcon />
+                      <RhUiBranchIcon />
                     </DataListCell>,
                     <DataListCell key="primary content">
                       <div id="ex-item1">Primary content</div>
@@ -237,7 +237,7 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell isIcon key="icon">
-                      <CodeBranchIcon />
+                      <RhUiBranchIcon />
                     </DataListCell>,
                     <DataListCell key="secondary content">
                       <div id="ex-item2">Secondary content</div>
@@ -313,7 +313,7 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell isIcon key="icon">
-                      <CodeBranchIcon />
+                      <RhUiBranchIcon />
                     </DataListCell>,
                     <DataListCell key="tertiary content">
                       <div id="ex-item3">Tertiary content</div>

--- a/packages/react-core/src/demos/DataList/examples/DataListStaticBottomPagination.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListStaticBottomPagination.tsx
@@ -27,7 +27,7 @@ import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { rows } from '@patternfly/react-core/dist/esm/demos/sampleData';
 
@@ -153,7 +153,7 @@ export const DataListStaticBottomPagination: React.FunctionComponent = () => {
                             <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                               <FlexItem>
                                 <Icon>
-                                  <RhUiBranchIcon />
+                                  <RhUiBranchFillIcon />
                                 </Icon>{' '}
                                 {threads}
                                 <span className="pf-v6-screen-reader">Branches</span>

--- a/packages/react-core/src/demos/DataList/examples/DataListStaticBottomPagination.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListStaticBottomPagination.tsx
@@ -26,8 +26,8 @@ import {
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { rows } from '@patternfly/react-core/dist/esm/demos/sampleData';
 
@@ -153,7 +153,7 @@ export const DataListStaticBottomPagination: React.FunctionComponent = () => {
                             <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                               <FlexItem>
                                 <Icon>
-                                  <CodeBranchIcon />
+                                  <RhUiBranchIcon />
                                 </Icon>{' '}
                                 {threads}
                                 <span className="pf-v6-screen-reader">Branches</span>

--- a/packages/react-core/src/demos/DataListDemo.md
+++ b/packages/react-core/src/demos/DataListDemo.md
@@ -5,7 +5,7 @@ section: components
 
 import { Fragment, useState } from 'react';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';

--- a/packages/react-core/src/demos/DataListDemo.md
+++ b/packages/react-core/src/demos/DataListDemo.md
@@ -5,7 +5,7 @@ section: components
 
 import { Fragment, useState } from 'react';
 
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -4,7 +4,7 @@ section: patterns
 ---
 
 import { Fragment, useState } from 'react';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -4,7 +4,7 @@ section: patterns
 ---
 
 import { Fragment, useState } from 'react';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';

--- a/packages/react-core/src/demos/Tabs.md
+++ b/packages/react-core/src/demos/Tabs.md
@@ -7,7 +7,7 @@ import { Fragment, useCallback, useRef, useState } from 'react';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiInformationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-information-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-large-to-small-icon';

--- a/packages/react-core/src/demos/Tabs.md
+++ b/packages/react-core/src/demos/Tabs.md
@@ -7,7 +7,7 @@ import { Fragment, useCallback, useRef, useState } from 'react';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiInformationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-information-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-large-to-small-icon';

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
@@ -39,8 +39,8 @@ import {
   MenuToggle
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -231,7 +231,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -274,7 +274,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -328,7 +328,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -371,7 +371,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
@@ -40,7 +40,7 @@ import {
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -231,7 +231,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -274,7 +274,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -328,7 +328,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -371,7 +371,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
@@ -39,8 +39,8 @@ import {
   MenuToggle
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -231,7 +231,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -274,7 +274,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -328,7 +328,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -371,7 +371,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
@@ -40,7 +40,7 @@ import {
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -231,7 +231,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -274,7 +274,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -328,7 +328,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -371,7 +371,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
@@ -40,7 +40,7 @@ import {
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -231,7 +231,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -274,7 +274,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -328,7 +328,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -371,7 +371,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <RhUiBranchIcon /> 10
+                        <RhUiBranchFillIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
@@ -39,8 +39,8 @@ import {
   MenuToggle
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
@@ -231,7 +231,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -274,7 +274,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -328,7 +328,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4
@@ -371,7 +371,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                     </FlexItem>
                     <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                       <FlexItem>
-                        <CodeBranchIcon /> 10
+                        <RhUiBranchIcon /> 10
                       </FlexItem>
                       <FlexItem>
                         <RhUiCodeIcon /> 4

--- a/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
@@ -50,7 +50,7 @@ import {
 } from '@patternfly/react-table';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-large-to-small-icon';
@@ -257,7 +257,7 @@ export const TablesAndTabs = () => {
               <Flex>
                 <FlexItem>{repo.branches}</FlexItem>
                 <FlexItem>
-                  <RhUiBranchIcon key="icon" />
+                  <RhUiBranchFillIcon key="icon" />
                 </FlexItem>
               </Flex>
             </Td>

--- a/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
@@ -50,7 +50,7 @@ import {
 } from '@patternfly/react-table';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-large-to-small-icon';
@@ -257,7 +257,7 @@ export const TablesAndTabs = () => {
               <Flex>
                 <FlexItem>{repo.branches}</FlexItem>
                 <FlexItem>
-                  <CodeBranchIcon key="icon" />
+                  <RhUiBranchIcon key="icon" />
                 </FlexItem>
               </Flex>
             </Td>

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
@@ -18,7 +18,7 @@ import {
   Spinner,
   SearchInput
 } from '@patternfly/react-core';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
@@ -193,7 +193,7 @@ export class MenuDemo extends Component {
         </Title>
         <Menu onSelect={this.onSimpleSelect} activeItemId={activeItem} id="menu-with-icons">
           <MenuList>
-            <MenuItem id="icons-menu-item-1" icon={<RhUiBranchIcon id="code-branch-icon" />} itemId={0}>
+            <MenuItem id="icons-menu-item-1" icon={<RhUiBranchFillIcon id="code-branch-icon" />} itemId={0}>
               From Git
             </MenuItem>
             <MenuItem id="icons-menu-item-2" icon={<LayerGroupIcon id="layer-group-icon" />} itemId={1}>
@@ -405,15 +405,21 @@ export class MenuDemo extends Component {
         </Title>
         <Menu id="menu-with-description" onSelect={this.onSimpleSelect} activeItemId={activeItem}>
           <MenuList>
-            <MenuItem id="description-item-1" icon={<RhUiBranchIcon />} description="Description" itemId={0}>
+            <MenuItem id="description-item-1" icon={<RhUiBranchFillIcon />} description="Description" itemId={0}>
               Action 1
             </MenuItem>
-            <MenuItem id="description-item-2" isDisabled icon={<RhUiBranchIcon />} description="Description" itemId={1}>
+            <MenuItem
+              id="description-item-2"
+              isDisabled
+              icon={<RhUiBranchFillIcon />}
+              description="Description"
+              itemId={1}
+            >
               Action 2 disabled
             </MenuItem>
             <MenuItem
               id="description-item-3"
-              icon={<RhUiBranchIcon />}
+              icon={<RhUiBranchFillIcon />}
               description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
               itemId={2}
             >
@@ -446,7 +452,7 @@ export class MenuDemo extends Component {
                 isSelected={selectedItems.indexOf(0) !== -1}
                 actions={
                   <MenuItemAction
-                    icon={<RhUiBranchIcon />}
+                    icon={<RhUiBranchFillIcon />}
                     actionId="code"
                     // eslint-disable-next-line no-console
                     onClick={() => console.log('clicked on code icon')}

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
@@ -18,7 +18,7 @@ import {
   Spinner,
   SearchInput
 } from '@patternfly/react-core';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
@@ -193,7 +193,7 @@ export class MenuDemo extends Component {
         </Title>
         <Menu onSelect={this.onSimpleSelect} activeItemId={activeItem} id="menu-with-icons">
           <MenuList>
-            <MenuItem id="icons-menu-item-1" icon={<CodeBranchIcon id="code-branch-icon" />} itemId={0}>
+            <MenuItem id="icons-menu-item-1" icon={<RhUiBranchIcon id="code-branch-icon" />} itemId={0}>
               From Git
             </MenuItem>
             <MenuItem id="icons-menu-item-2" icon={<LayerGroupIcon id="layer-group-icon" />} itemId={1}>
@@ -405,15 +405,15 @@ export class MenuDemo extends Component {
         </Title>
         <Menu id="menu-with-description" onSelect={this.onSimpleSelect} activeItemId={activeItem}>
           <MenuList>
-            <MenuItem id="description-item-1" icon={<CodeBranchIcon />} description="Description" itemId={0}>
+            <MenuItem id="description-item-1" icon={<RhUiBranchIcon />} description="Description" itemId={0}>
               Action 1
             </MenuItem>
-            <MenuItem id="description-item-2" isDisabled icon={<CodeBranchIcon />} description="Description" itemId={1}>
+            <MenuItem id="description-item-2" isDisabled icon={<RhUiBranchIcon />} description="Description" itemId={1}>
               Action 2 disabled
             </MenuItem>
             <MenuItem
               id="description-item-3"
-              icon={<CodeBranchIcon />}
+              icon={<RhUiBranchIcon />}
               description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
               itemId={2}
             >
@@ -446,7 +446,7 @@ export class MenuDemo extends Component {
                 isSelected={selectedItems.indexOf(0) !== -1}
                 actions={
                   <MenuItemAction
-                    icon={<CodeBranchIcon />}
+                    icon={<RhUiBranchIcon />}
                     actionId="code"
                     // eslint-disable-next-line no-console
                     onClick={() => console.log('clicked on code icon')}

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDrilldownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDrilldownDemo.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -189,7 +189,7 @@ export class MenuDrilldownDemo extends Component {
                     Add storage
                   </MenuItem>
                   <Divider component="li" />
-                  <MenuItem icon={<RhUiBranchIcon />} itemId="git">
+                  <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                     From Git
                   </MenuItem>
                   <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDrilldownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDrilldownDemo.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -189,7 +189,7 @@ export class MenuDrilldownDemo extends Component {
                     Add storage
                   </MenuItem>
                   <Divider component="li" />
-                  <MenuItem icon={<CodeBranchIcon />} itemId="git">
+                  <MenuItem icon={<RhUiBranchIcon />} itemId="git">
                     From Git
                   </MenuItem>
                   <MenuItem icon={<LayerGroupIcon />} itemId="container">

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
@@ -27,7 +27,7 @@ import {
   Checkbox
 } from '@patternfly/react-core';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import t_global_color_brand_default from '@patternfly/react-tokens/dist/esm/t_global_color_brand_default';
 
@@ -801,7 +801,7 @@ export const TableComposableDemo = () => {
       } else if (index === 1) {
         return (
           <>
-            <RhUiBranchIcon key="icon" /> {cell}
+            <RhUiBranchFillIcon key="icon" /> {cell}
           </>
         );
       } else if (index === 2) {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
@@ -26,8 +26,8 @@ import {
   StackItem,
   Checkbox
 } from '@patternfly/react-core';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import t_global_color_brand_default from '@patternfly/react-tokens/dist/esm/t_global_color_brand_default';
 
@@ -801,7 +801,7 @@ export const TableComposableDemo = () => {
       } else if (index === 1) {
         return (
           <>
-            <CodeBranchIcon key="icon" /> {cell}
+            <RhUiBranchIcon key="icon" /> {cell}
           </>
         );
       } else if (index === 2) {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
@@ -2,8 +2,8 @@ import { Component } from 'react';
 import { compoundExpand, IRow, ICell, IRowCell } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
@@ -43,7 +43,7 @@ export class TableCompoundExpandableDemo extends Component<TableProps, TableStat
             {
               title: (
                 <>
-                  <CodeBranchIcon key="icon" /> 10
+                  <RhUiBranchIcon key="icon" /> 10
                 </>
               ),
               props: { isOpen: true, ariaControls: 'compoound-expansion-table-1' }
@@ -120,7 +120,7 @@ export class TableCompoundExpandableDemo extends Component<TableProps, TableStat
             {
               title: (
                 <>
-                  <CodeBranchIcon key="icon" /> 3
+                  <RhUiBranchIcon key="icon" /> 3
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-4' }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
@@ -3,7 +3,7 @@ import { compoundExpand, IRow, ICell, IRowCell } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
@@ -43,7 +43,7 @@ export class TableCompoundExpandableDemo extends Component<TableProps, TableStat
             {
               title: (
                 <>
-                  <RhUiBranchIcon key="icon" /> 10
+                  <RhUiBranchFillIcon key="icon" /> 10
                 </>
               ),
               props: { isOpen: true, ariaControls: 'compoound-expansion-table-1' }
@@ -120,7 +120,7 @@ export class TableCompoundExpandableDemo extends Component<TableProps, TableStat
             {
               title: (
                 <>
-                  <RhUiBranchIcon key="icon" /> 3
+                  <RhUiBranchFillIcon key="icon" /> 3
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-4' }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
@@ -3,7 +3,7 @@ import { compoundExpand, IRow, ICell, IRowCell } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
@@ -43,7 +43,7 @@ export class TableEditableCompoundExpandableDemo extends Component<TableProps, T
             {
               title: (
                 <>
-                  <RhUiBranchIcon key="icon" /> 10
+                  <RhUiBranchFillIcon key="icon" /> 10
                 </>
               ),
               props: { isOpen: true, ariaControls: 'compoound-expansion-table-1' }
@@ -120,7 +120,7 @@ export class TableEditableCompoundExpandableDemo extends Component<TableProps, T
             {
               title: (
                 <>
-                  <RhUiBranchIcon key="icon" /> 3
+                  <RhUiBranchFillIcon key="icon" /> 3
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-4' }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
@@ -2,8 +2,8 @@ import { Component } from 'react';
 import { compoundExpand, IRow, ICell, IRowCell } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
@@ -43,7 +43,7 @@ export class TableEditableCompoundExpandableDemo extends Component<TableProps, T
             {
               title: (
                 <>
-                  <CodeBranchIcon key="icon" /> 10
+                  <RhUiBranchIcon key="icon" /> 10
                 </>
               ),
               props: { isOpen: true, ariaControls: 'compoound-expansion-table-1' }
@@ -120,7 +120,7 @@ export class TableEditableCompoundExpandableDemo extends Component<TableProps, T
             {
               title: (
                 <>
-                  <CodeBranchIcon key="icon" /> 3
+                  <RhUiBranchIcon key="icon" /> 3
                 </>
               ),
               props: { isOpen: false, ariaControls: 'compoound-expansion-table-4' }

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -44,7 +44,7 @@ The documentation for the deprecated table implementation can be found under the
 import { Fragment, isValidElement, useCallback, useEffect, useRef, useState, useLayoutEffect } from 'react';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -43,8 +43,8 @@ The documentation for the deprecated table implementation can be found under the
 
 import { Fragment, isValidElement, useCallback, useEffect, useRef, useState, useLayoutEffect } from 'react';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';

--- a/packages/react-table/src/components/Table/examples/TableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableCompoundExpandable.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td, TdProps, ExpandableRowContent } from '@patternfly/react-table';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 interface Repository {
@@ -83,7 +83,7 @@ export const TableCompoundExpandable: React.FunctionComponent = () => {
                 dataLabel={columnNames.branches}
                 compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
               >
-                <CodeBranchIcon key="icon" /> {repo.branches}
+                <RhUiBranchIcon key="icon" /> {repo.branches}
               </Td>
               <Td
                 width={10}

--- a/packages/react-table/src/components/Table/examples/TableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableCompoundExpandable.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td, TdProps, ExpandableRowContent } from '@patternfly/react-table';
 
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 interface Repository {
@@ -83,7 +83,7 @@ export const TableCompoundExpandable: React.FunctionComponent = () => {
                 dataLabel={columnNames.branches}
                 compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
               >
-                <RhUiBranchIcon key="icon" /> {repo.branches}
+                <RhUiBranchFillIcon key="icon" /> {repo.branches}
               </Td>
               <Td
                 width={10}

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -51,7 +51,7 @@ import { DragDropSort } from '@patternfly/react-drag-drop';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -51,7 +51,7 @@ import { DragDropSort } from '@patternfly/react-drag-drop';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';

--- a/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
+++ b/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
@@ -16,8 +16,8 @@ import {
   SelectOption,
   PaginationVariant
 } from '@patternfly/react-core';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { DashboardWrapper } from '@patternfly/react-table/dist/esm/demos/DashboardWrapper';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
@@ -226,7 +226,7 @@ export const TableCompoundExpansion: React.FunctionComponent = () => {
                   >
                     <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                       <FlexItem>
-                        <CodeBranchIcon key="icon" />
+                        <RhUiBranchIcon key="icon" />
                       </FlexItem>
                       <FlexItem>{repo.branches}</FlexItem>
                     </Flex>

--- a/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
+++ b/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
@@ -17,7 +17,7 @@ import {
   PaginationVariant
 } from '@patternfly/react-core';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { DashboardWrapper } from '@patternfly/react-table/dist/esm/demos/DashboardWrapper';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
@@ -226,7 +226,7 @@ export const TableCompoundExpansion: React.FunctionComponent = () => {
                   >
                     <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                       <FlexItem>
-                        <RhUiBranchIcon key="icon" />
+                        <RhUiBranchFillIcon key="icon" />
                       </FlexItem>
                       <FlexItem>{repo.branches}</FlexItem>
                     </Flex>

--- a/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
+++ b/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
@@ -33,8 +33,8 @@ import CloneIcon from '@patternfly/react-icons/dist/esm/icons/clone-icon';
 import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
 import SyncIcon from '@patternfly/react-icons/dist/esm/icons/sync-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhMicronsSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-large-to-small-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { DashboardWrapper } from '@patternfly/react-table/dist/esm/demos/DashboardWrapper';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
@@ -277,7 +277,7 @@ export const TableSortableResponsive: React.FunctionComponent = () => {
                     <Td dataLabel={columns[1]} width={10}>
                       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                         <FlexItem>
-                          <CodeBranchIcon key="icon" />
+                          <RhUiBranchIcon key="icon" />
                         </FlexItem>
                         <FlexItem>{row.threads}</FlexItem>
                       </Flex>

--- a/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
+++ b/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
@@ -34,7 +34,7 @@ import EditIcon from '@patternfly/react-icons/dist/esm/icons/edit-icon';
 import SyncIcon from '@patternfly/react-icons/dist/esm/icons/sync-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhMicronsSortDownLargeToSmallIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-sort-down-large-to-small-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import { DashboardWrapper } from '@patternfly/react-table/dist/esm/demos/DashboardWrapper';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
@@ -277,7 +277,7 @@ export const TableSortableResponsive: React.FunctionComponent = () => {
                     <Td dataLabel={columns[1]} width={10}>
                       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                         <FlexItem>
-                          <RhUiBranchIcon key="icon" />
+                          <RhUiBranchFillIcon key="icon" />
                         </FlexItem>
                         <FlexItem>{row.threads}</FlexItem>
                       </Flex>

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableCompoundExpandable.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableCompoundExpandable.tsx
@@ -3,7 +3,7 @@ import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-tab
 import { compoundExpand } from '@patternfly/react-table';
 
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
@@ -76,7 +76,7 @@ export const LegacyTableCompoundExpandable: React.FunctionComponent = () => {
         {
           title: (
             <Fragment>
-              <RhUiBranchIcon key="icon" /> {repo.branches}
+              <RhUiBranchFillIcon key="icon" /> {repo.branches}
             </Fragment>
           ),
           props: {

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableCompoundExpandable.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableCompoundExpandable.tsx
@@ -2,8 +2,8 @@ import { Fragment, useState } from 'react';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 import { compoundExpand } from '@patternfly/react-table';
 
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
@@ -76,7 +76,7 @@ export const LegacyTableCompoundExpandable: React.FunctionComponent = () => {
         {
           title: (
             <Fragment>
-              <CodeBranchIcon key="icon" /> {repo.branches}
+              <RhUiBranchIcon key="icon" /> {repo.branches}
             </Fragment>
           ),
           props: {

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -15,8 +15,8 @@ This deprecated `Table` component is configuration-based and takes a less declar
 
 import { Fragment, isValidElement, useCallback, useEffect, useRef, useState } from 'react';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -16,7 +16,8 @@ This deprecated `Table` component is configuration-based and takes a less declar
 import { Fragment, isValidElement, useCallback, useEffect, useRef, useState } from 'react';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
-import RhUiBranchIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-icon';
+import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
+import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';


### PR DESCRIPTION
We might want a microns version for this - it looks significantly lighter weight-wise.

Part of https://github.com/patternfly/patternfly-react/issues/12401. Breaking into separate PRs so it is easier to review.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the “code branch” icon with the “Rh UI branch” icon across DataList, Menu, Table, Tabs, PrimaryDetail, CustomMenus, and integration demo app examples.
  * Updated all affected “branch” icon placements (including expandable rows, drilldown menus, and table cells) to match the new icon.

* **Documentation**
  * Updated example and demo Markdown to use the new icon import in rendered snippets.  

Visual updates only—no changes to behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->