### PR TITLE
fix(ExternalLinkAltIcon): Replace ExternalLinkAltIcon with RhUiExternalLinkIcon

### DIFF
--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -4,7 +4,7 @@ import { css } from '@patternfly/react-styles';
 import topOffset from '@patternfly/react-tokens/dist/esm/c_menu_m_flyout__menu_top_offset';
 import rightOffset from '@patternfly/react-tokens/dist/esm/c_menu_m_flyout__menu_m_left_right_offset';
 import leftOffset from '@patternfly/react-tokens/dist/esm/c_menu_m_flyout__menu_left_offset';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
@@ -389,7 +389,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
           <span className={css(styles.menuItemText)}>{children}</span>
           {isExternalLink && (
             <span className={css(styles.menuItemExternalIcon)}>
-              <ExternalLinkAltIcon />
+              <RhUiExternalLinkIcon />
             </span>
           )}
           {(flyoutMenu || direction === 'down') && (

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -4,7 +4,7 @@ import { css } from '@patternfly/react-styles';
 import topOffset from '@patternfly/react-tokens/dist/esm/c_menu_m_flyout__menu_top_offset';
 import rightOffset from '@patternfly/react-tokens/dist/esm/c_menu_m_flyout__menu_m_left_right_offset';
 import leftOffset from '@patternfly/react-tokens/dist/esm/c_menu_m_flyout__menu_left_offset';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
@@ -389,7 +389,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
           <span className={css(styles.menuItemText)}>{children}</span>
           {isExternalLink && (
             <span className={css(styles.menuItemExternalIcon)}>
-              <RhUiExternalLinkIcon />
+              <RhMicronsExternalLinkIcon />
             </span>
           )}
           {(flyoutMenu || direction === 'down') && (

--- a/packages/react-core/src/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/components/Wizard/examples/Wizard.md
@@ -49,7 +49,7 @@ WizardNavItem,
 WizardNav,
 WizardHeader
 } from '@patternfly/react-core';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 import CogsIcon from '@patternfly/react-icons/dist/esm/icons/cogs-icon';
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';

--- a/packages/react-core/src/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/components/Wizard/examples/Wizard.md
@@ -49,7 +49,7 @@ WizardNavItem,
 WizardNav,
 WizardHeader
 } from '@patternfly/react-core';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 import CogsIcon from '@patternfly/react-icons/dist/esm/icons/cogs-icon';
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';

--- a/packages/react-core/src/components/Wizard/examples/WizardWithNavAnchors.tsx
+++ b/packages/react-core/src/components/Wizard/examples/WizardWithNavAnchors.tsx
@@ -1,5 +1,5 @@
 import { Button, Wizard, WizardStep } from '@patternfly/react-core';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 
 export const WizardWithNavAnchors: React.FunctionComponent = () => (
@@ -7,7 +7,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => (
     <WizardStep
       name={
         <>
-          <RhUiExternalLinkIcon /> PF3
+          <RhMicronsExternalLinkIcon /> PF3
         </>
       }
       id="navanchors-pf3-step"
@@ -18,7 +18,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => (
     <WizardStep
       name={
         <>
-          <RhUiExternalLinkIcon /> PF4
+          <RhMicronsExternalLinkIcon /> PF4
         </>
       }
       id="navanchors-pf4-step"

--- a/packages/react-core/src/components/Wizard/examples/WizardWithNavAnchors.tsx
+++ b/packages/react-core/src/components/Wizard/examples/WizardWithNavAnchors.tsx
@@ -1,5 +1,5 @@
 import { Button, Wizard, WizardStep } from '@patternfly/react-core';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 
 export const WizardWithNavAnchors: React.FunctionComponent = () => (
@@ -7,7 +7,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => (
     <WizardStep
       name={
         <>
-          <ExternalLinkAltIcon /> PF3
+          <RhUiExternalLinkIcon /> PF3
         </>
       }
       id="navanchors-pf3-step"
@@ -18,7 +18,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => (
     <WizardStep
       name={
         <>
-          <ExternalLinkAltIcon /> PF4
+          <RhUiExternalLinkIcon /> PF4
         </>
       }
       id="navanchors-pf4-step"

--- a/packages/react-core/src/demos/CardDemos.md
+++ b/packages/react-core/src/demos/CardDemos.md
@@ -4,11 +4,7 @@ section: components
 ---
 
 import { Fragment, useState } from 'react';
-import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
-import RhUiInformationFillIcon from '@patternfly/react-icons/dist/js/icons/rh-ui-information-fill-icon';
-import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/js/icons/rh-microns-caret-right-icon';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { RhUiCheckCircleFillIcon, RhUiErrorFillIcon, RhUiWarningFillIcon, RhUiNotificationFillIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon, RhMicronsCaretRightIcon, RhUiCheckCircleFillIcon, RhUiErrorFillIcon, RhUiExternalLinkIcon, RhUiInformationFillIcon, RhUiWarningFillIcon, RhUiNotificationFillIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { Chart, ChartAxis, ChartGroup, ChartVoronoiContainer, ChartStack, ChartBar, ChartTooltip, ChartDonutThreshold, ChartDonutUtilization, ChartArea, ChartContainer, ChartLabel } from '@patternfly/react-charts/victory';
 import chart_color_yellow_100 from '@patternfly/react-tokens/dist/esm/chart_color_yellow_100';

--- a/packages/react-core/src/demos/CardDemos.md
+++ b/packages/react-core/src/demos/CardDemos.md
@@ -4,7 +4,7 @@ section: components
 ---
 
 import { Fragment, useState } from 'react';
-import { EllipsisVIcon, RhMicronsCaretRightIcon, RhUiCheckCircleFillIcon, RhUiErrorFillIcon, RhUiExternalLinkIcon, RhUiInformationFillIcon, RhUiWarningFillIcon, RhUiNotificationFillIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon, RhMicronsCaretRightIcon, RhUiCheckCircleFillIcon, RhUiErrorFillIcon, RhMicronsExternalLinkIcon, RhUiInformationFillIcon, RhUiWarningFillIcon, RhUiNotificationFillIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { Chart, ChartAxis, ChartGroup, ChartVoronoiContainer, ChartStack, ChartBar, ChartTooltip, ChartDonutThreshold, ChartDonutUtilization, ChartArea, ChartContainer, ChartLabel } from '@patternfly/react-charts/victory';
 import chart_color_yellow_100 from '@patternfly/react-tokens/dist/esm/chart_color_yellow_100';

--- a/packages/react-core/src/demos/Toolbar.md
+++ b/packages/react-core/src/demos/Toolbar.md
@@ -7,7 +7,7 @@ import { Fragment, useState } from 'react';
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';

--- a/packages/react-core/src/demos/Toolbar.md
+++ b/packages/react-core/src/demos/Toolbar.md
@@ -7,7 +7,7 @@ import { Fragment, useState } from 'react';
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';

--- a/packages/react-core/src/demos/examples/Card/CardHorizontalGrid.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardHorizontalGrid.tsx
@@ -22,7 +22,7 @@ import {
 } from '@patternfly/react-core';
 import RhUiInformationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-information-fill-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 export const CardHorizontalGrid: React.FunctionComponent = () => {
@@ -241,7 +241,7 @@ export const CardHorizontalGrid: React.FunctionComponent = () => {
                   <ListItem>
                     <a href="#">
                       OpenShift 4.5: Top Tasks
-                      <RhUiExternalLinkIcon />
+                      <RhMicronsExternalLinkIcon />
                     </a>
                   </ListItem>
                   <ListItem>

--- a/packages/react-core/src/demos/examples/Card/CardHorizontalGrid.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardHorizontalGrid.tsx
@@ -22,7 +22,7 @@ import {
 } from '@patternfly/react-core';
 import RhUiInformationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-information-fill-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 export const CardHorizontalGrid: React.FunctionComponent = () => {
@@ -241,7 +241,7 @@ export const CardHorizontalGrid: React.FunctionComponent = () => {
                   <ListItem>
                     <a href="#">
                       OpenShift 4.5: Top Tasks
-                      <ExternalLinkAltIcon />
+                      <RhUiExternalLinkIcon />
                     </a>
                   </ListItem>
                   <ListItem>

--- a/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
+++ b/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
@@ -23,7 +23,7 @@ import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/Dashboard
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
@@ -430,7 +430,7 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
                 ref={toggleRef}
                 isExpanded={externalExpandedMobile}
                 onClick={onExternalToggleMobile}
-                icon={<ExternalLinkAltIcon />}
+                icon={<RhUiExternalLinkIcon />}
                 aria-label="External logs"
               />
             )}

--- a/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
+++ b/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
@@ -23,7 +23,7 @@ import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/Dashboard
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
@@ -430,7 +430,7 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
                 ref={toggleRef}
                 isExpanded={externalExpandedMobile}
                 onClick={onExternalToggleMobile}
-                icon={<RhUiExternalLinkIcon />}
+                icon={<RhMicronsExternalLinkIcon />}
                 aria-label="External logs"
               />
             )}

--- a/packages/react-core/src/deprecated/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/deprecated/components/Wizard/examples/Wizard.md
@@ -13,7 +13,7 @@ import { Fragment, useEffect, useRef, useState } from 'react';
 import { Button, Drawer, DrawerActions, DrawerCloseButton, DrawerColorVariant,
 DrawerContent, DrawerContentBody, DrawerHead, DrawerPanelContent, DrawerSection, ModalVariant, Alert, EmptyState, EmptyStateFooter, EmptyStateBody, EmptyStateActions, Title, Progress, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { Wizard as WizardDeprecated, WizardFooter as WizardFooterDeprecated, WizardContextConsumer as WizardContextConsumerDeprecated } from '@patternfly/react-core/deprecated';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 import CogsIcon from '@patternfly/react-icons/dist/esm/icons/cogs-icon';
 

--- a/packages/react-core/src/deprecated/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/deprecated/components/Wizard/examples/Wizard.md
@@ -13,7 +13,7 @@ import { Fragment, useEffect, useRef, useState } from 'react';
 import { Button, Drawer, DrawerActions, DrawerCloseButton, DrawerColorVariant,
 DrawerContent, DrawerContentBody, DrawerHead, DrawerPanelContent, DrawerSection, ModalVariant, Alert, EmptyState, EmptyStateFooter, EmptyStateBody, EmptyStateActions, Title, Progress, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { Wizard as WizardDeprecated, WizardFooter as WizardFooterDeprecated, WizardContextConsumer as WizardContextConsumerDeprecated } from '@patternfly/react-core/deprecated';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 import CogsIcon from '@patternfly/react-icons/dist/esm/icons/cogs-icon';
 

--- a/packages/react-core/src/deprecated/components/Wizard/examples/WizardAnchorsForNavItems.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/examples/WizardAnchorsForNavItems.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@patternfly/react-core';
 import { Wizard as WizardDeprecated } from '@patternfly/react-core/deprecated';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 
 export const WizardWithNavAnchors: React.FunctionComponent = () => {
@@ -8,7 +8,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => {
     {
       name: (
         <div>
-          <RhUiExternalLinkIcon /> PF3
+          <RhMicronsExternalLinkIcon /> PF3
         </div>
       ),
       component: <p>Step 1: Read about PF3</p>,
@@ -17,7 +17,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => {
     {
       name: (
         <div>
-          <RhUiExternalLinkIcon /> PF4
+          <RhMicronsExternalLinkIcon /> PF4
         </div>
       ),
       component: <p>Step 2: Read about PF4</p>,

--- a/packages/react-core/src/deprecated/components/Wizard/examples/WizardAnchorsForNavItems.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/examples/WizardAnchorsForNavItems.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@patternfly/react-core';
 import { Wizard as WizardDeprecated } from '@patternfly/react-core/deprecated';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 
 export const WizardWithNavAnchors: React.FunctionComponent = () => {
@@ -8,7 +8,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => {
     {
       name: (
         <div>
-          <ExternalLinkAltIcon /> PF3
+          <RhUiExternalLinkIcon /> PF3
         </div>
       ),
       component: <p>Step 1: Read about PF3</p>,
@@ -17,7 +17,7 @@ export const WizardWithNavAnchors: React.FunctionComponent = () => {
     {
       name: (
         <div>
-          <ExternalLinkAltIcon /> PF4
+          <RhUiExternalLinkIcon /> PF4
         </div>
       ),
       component: <p>Step 2: Read about PF4</p>,

--- a/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { Button, ButtonProps, ButtonSize, Tooltip } from '@patternfly/react-core';
 import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 import { Link } from 'react-router-dom';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
@@ -42,7 +42,7 @@ export class ButtonDemo extends Component<ButtonProps, ButtonDemoState> {
     className: spacing.mSm,
     component: 'a',
     href: 'https://github.com/patternfly/patternfly-react',
-    icon: <RhUiExternalLinkIcon />,
+    icon: <RhMicronsExternalLinkIcon />,
     target: '_blank'
   };
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { Button, ButtonProps, ButtonSize, Tooltip } from '@patternfly/react-core';
 import RhUiAddCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-circle-fill-icon';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 import { Link } from 'react-router-dom';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
@@ -42,7 +42,7 @@ export class ButtonDemo extends Component<ButtonProps, ButtonDemoState> {
     className: spacing.mSm,
     component: 'a',
     href: 'https://github.com/patternfly/patternfly-react',
-    icon: <ExternalLinkAltIcon />,
+    icon: <RhUiExternalLinkIcon />,
     target: '_blank'
   };
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/WizardDemo/WizardDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/WizardDemo/WizardDemo.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { Button, Wizard, WizardHeader, WizardStep, Modal } from '@patternfly/react-core';
 
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 
 interface WizardDemoState {
@@ -104,7 +104,7 @@ class WizardDemo extends Component<React.HTMLProps<HTMLDivElement>, WizardDemoSt
           <WizardStep
             name={
               <>
-                <ExternalLinkAltIcon /> Read about PF3
+                <RhUiExternalLinkIcon /> Read about PF3
               </>
             }
             id="wizard-anchor-pf3"
@@ -115,7 +115,7 @@ class WizardDemo extends Component<React.HTMLProps<HTMLDivElement>, WizardDemoSt
           <WizardStep
             name={
               <>
-                <ExternalLinkAltIcon /> Read about PF4
+                <RhUiExternalLinkIcon /> Read about PF4
               </>
             }
             id="wizard-anchor-pf4"

--- a/packages/react-integration/demo-app-ts/src/components/demos/WizardDemo/WizardDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/WizardDemo/WizardDemo.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { Button, Wizard, WizardHeader, WizardStep, Modal } from '@patternfly/react-core';
 
-import RhUiExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-external-link-icon';
+import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 
 interface WizardDemoState {
@@ -104,7 +104,7 @@ class WizardDemo extends Component<React.HTMLProps<HTMLDivElement>, WizardDemoSt
           <WizardStep
             name={
               <>
-                <RhUiExternalLinkIcon /> Read about PF3
+                <RhMicronsExternalLinkIcon /> Read about PF3
               </>
             }
             id="wizard-anchor-pf3"
@@ -115,7 +115,7 @@ class WizardDemo extends Component<React.HTMLProps<HTMLDivElement>, WizardDemoSt
           <WizardStep
             name={
               <>
-                <RhUiExternalLinkIcon /> Read about PF4
+                <RhMicronsExternalLinkIcon /> Read about PF4
               </>
             }
             id="wizard-anchor-pf4"


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-react/issues/12401. Breaking into separate PRs so it is easier to review.

Tried in first commit with RhUiExternalLinkIcon but it was a little hard to see compared to ours. Tried Micron version in second commit.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated external link icons throughout UI components and documentation examples to use a new icon design for improved visual consistency across the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->