### PR TITLE
fix(InfrastructureIcons): replaced with RH brand icons part 1

### DIFF
--- a/packages/react-core/src/components/Alert/examples/Alert.md
+++ b/packages/react-core/src/components/Alert/examples/Alert.md
@@ -11,7 +11,7 @@ import { Fragment, useEffect, useState } from 'react';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
-import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 

--- a/packages/react-core/src/components/Alert/examples/AlertCustomIcons.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertCustomIcons.tsx
@@ -3,7 +3,7 @@ import { Alert } from '@patternfly/react-core';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
-import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
 
 export const AlertCustomIcons: React.FunctionComponent = () => (
@@ -11,7 +11,7 @@ export const AlertCustomIcons: React.FunctionComponent = () => (
     <Alert customIcon={<RhUiUsersFillIcon />} title="Default alert title" />
     <Alert customIcon={<RhUiContainerFillIcon />} variant="info" title="Info alert title" />
     <Alert customIcon={<DatabaseIcon />} variant="success" title="Success alert title" />
-    <Alert customIcon={<ServerIcon />} variant="warning" title="Warning alert title" />
+    <Alert customIcon={<RhUiServerStackFillIcon />} variant="warning" title="Warning alert title" />
     <Alert customIcon={<LaptopIcon />} variant="danger" title="Danger alert title" />
   </Fragment>
 );

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -24,11 +24,11 @@ import { Fragment, createRef, useEffect, useRef, useState } from 'react';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiTableIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-table-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldown.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldown.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 export const MenuWithDrilldown: React.FunctionComponent = () => {
@@ -153,18 +153,18 @@ export const MenuWithDrilldown: React.FunctionComponent = () => {
           </MenuItem>
           <MenuItem
             itemId="group:storage"
-            icon={<StorageDomainIcon />}
+            icon={<RhUiStorageDomainFillIcon />}
             direction="down"
             drilldownMenu={
               <DrilldownMenu id="drilldown-drilldownMenuStorage">
-                <MenuItem itemId="group:storage_breadcrumb" icon={<StorageDomainIcon />} direction="up">
+                <MenuItem itemId="group:storage_breadcrumb" icon={<RhUiStorageDomainFillIcon />} direction="up">
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
                 <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From git
                 </MenuItem>
-                <MenuItem icon={<LayerGroupIcon />} itemId="container">
+                <MenuItem icon={<RhUiServerStackFillIcon />} itemId="container">
                   Container image
                 </MenuItem>
                 <MenuItem icon={<CubeIcon />} itemId="docker">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -19,9 +19,9 @@ import {
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import RhMicronsCaretLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-left-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
@@ -435,7 +435,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
             </MenuItem>
             <MenuItem
               itemId="group:storage"
-              icon={<StorageDomainIcon />}
+              icon={<RhUiStorageDomainFillIcon />}
               direction="down"
               onClick={() => setBreadcrumb(addStorageBreadcrumb)}
               drilldownMenu={
@@ -443,7 +443,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
                   <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                     From git
                   </MenuItem>
-                  <MenuItem icon={<LayerGroupIcon />} itemId="container">
+                  <MenuItem icon={<RhUiServerStackFillIcon />} itemId="container">
                     Container image
                   </MenuItem>
                   <MenuItem icon={<CubeIcon />} itemId="docker">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 export const MenuDrilldownInitialState: React.FunctionComponent = () => {
@@ -156,18 +156,18 @@ export const MenuDrilldownInitialState: React.FunctionComponent = () => {
           </MenuItem>
           <MenuItem
             itemId="group:storage"
-            icon={<StorageDomainIcon />}
+            icon={<RhUiStorageDomainFillIcon />}
             direction="down"
             drilldownMenu={
               <DrilldownMenu id="initial-state-drilldownMenuStorage">
-                <MenuItem itemId="group:storage_breadcrumb" icon={<StorageDomainIcon />} direction="up">
+                <MenuItem itemId="group:storage_breadcrumb" icon={<RhUiStorageDomainFillIcon />} direction="up">
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
                 <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From git
                 </MenuItem>
-                <MenuItem icon={<LayerGroupIcon />} itemId="container">
+                <MenuItem icon={<RhUiServerStackFillIcon />} itemId="container">
                   Container image
                 </MenuItem>
                 <MenuItem icon={<CubeIcon />} itemId="docker">

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownSubmenuFunctions.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownSubmenuFunctions.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 export const MenuWithDrilldownSubmenuFunctions: React.FunctionComponent = () => {
@@ -153,18 +153,18 @@ export const MenuWithDrilldownSubmenuFunctions: React.FunctionComponent = () => 
           </MenuItem>
           <MenuItem
             itemId="group:storage"
-            icon={<StorageDomainIcon />}
+            icon={<RhUiStorageDomainFillIcon />}
             direction="down"
             drilldownMenu={() => (
               <DrilldownMenu id="functions-drilldownMenuStorage">
-                <MenuItem itemId="group:storage_breadcrumb" icon={<StorageDomainIcon />} direction="up">
+                <MenuItem itemId="group:storage_breadcrumb" icon={<RhUiStorageDomainFillIcon />} direction="up">
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
                 <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From git
                 </MenuItem>
-                <MenuItem icon={<LayerGroupIcon />} itemId="container">
+                <MenuItem icon={<RhUiServerStackFillIcon />} itemId="container">
                   Container image
                 </MenuItem>
                 <MenuItem icon={<CubeIcon />} itemId="docker">

--- a/packages/react-core/src/components/Menu/examples/MenuWithIcons.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithIcons.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 export const MenuWithIcons: React.FunctionComponent = () => {
@@ -20,7 +20,7 @@ export const MenuWithIcons: React.FunctionComponent = () => {
           <MenuItem icon={<RhUiBranchFillIcon />} itemId={0}>
             From git
           </MenuItem>
-          <MenuItem icon={<LayerGroupIcon />} itemId={1}>
+          <MenuItem icon={<RhUiServerStackFillIcon />} itemId={1}>
             Container image
           </MenuItem>
           <MenuItem icon={<CubeIcon />} itemId={2}>

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -21,7 +21,7 @@ import { createRef, Fragment, useEffect, useRef, useState } from 'react';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
-import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
 import RhUiInfrastructureFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-infrastructure-fill-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';

--- a/packages/react-core/src/components/Tabs/examples/TabsIconAndText.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsIconAndText.tsx
@@ -3,7 +3,7 @@ import { Tabs, Tab, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
 import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-users-fill-icon';
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
-import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
 import RhUiInfrastructureFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-infrastructure-fill-icon';
 
@@ -69,7 +69,7 @@ export const TabsIconAndText: React.FunctionComponent = () => {
         title={
           <>
             <TabTitleIcon>
-              <ServerIcon />
+              <RhUiServerStackFillIcon />
             </TabTitleIcon>{' '}
             <TabTitleText>Server</TabTitleText>{' '}
           </>

--- a/packages/react-core/src/demos/CustomMenus/CustomMenus.md
+++ b/packages/react-core/src/demos/CustomMenus/CustomMenus.md
@@ -7,9 +7,9 @@ subsection: menus
 import { cloneElement, Fragment, useEffect, useRef, useState } from 'react';
 
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
@@ -18,7 +18,7 @@ import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';
 import brandImg from '../assets/PF-IconLogo.svg';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
-import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 import avatarImg from '../assets/avatarImg.svg';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';

--- a/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
@@ -9,9 +9,9 @@ import {
   Divider,
   MenuContainer
 } from '@patternfly/react-core';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 interface MenuHeightsType {
@@ -183,18 +183,18 @@ export const DrilldownMenuDemo: React.FunctionComponent = () => {
           </MenuItem>
           <MenuItem
             itemId="group:storage"
-            icon={<StorageDomainIcon />}
+            icon={<RhUiStorageDomainFillIcon />}
             direction="down"
             drilldownMenu={
               <DrilldownMenu id="drilldownMenuStorage">
-                <MenuItem itemId="group:storage_breadcrumb" icon={<StorageDomainIcon />} direction="up">
+                <MenuItem itemId="group:storage_breadcrumb" icon={<RhUiStorageDomainFillIcon />} direction="up">
                   Add storage
                 </MenuItem>
                 <Divider component="li" />
                 <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                   From Git
                 </MenuItem>
-                <MenuItem icon={<LayerGroupIcon />} itemId="container">
+                <MenuItem icon={<RhUiServerStackFillIcon />} itemId="container">
                   Container Image
                 </MenuItem>
                 <MenuItem icon={<CubeIcon />} itemId="docker">

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-core';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-notification-fill-icon';
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import RhUiClipboardFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-clipboard-fill-icon';
@@ -196,7 +196,7 @@ export class MenuDemo extends Component {
             <MenuItem id="icons-menu-item-1" icon={<RhUiBranchFillIcon id="code-branch-icon" />} itemId={0}>
               From Git
             </MenuItem>
-            <MenuItem id="icons-menu-item-2" icon={<LayerGroupIcon id="layer-group-icon" />} itemId={1}>
+            <MenuItem id="icons-menu-item-2" icon={<RhUiServerStackFillIcon id="layer-group-icon" />} itemId={1}>
               Container Image
             </MenuItem>
             <MenuItem id="icons-menu-item-3" icon={<CubeIcon id="cube-icon" />} itemId={2}>

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDrilldownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDrilldownDemo.tsx
@@ -1,8 +1,8 @@
 import { Component } from 'react';
 import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
-import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import RhUiBranchFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-branch-fill-icon';
-import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import RhUiStorageDomainFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-storage-domain-fill-icon';
+import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 
 /* eslint-disable no-console */
@@ -181,18 +181,18 @@ export class MenuDrilldownDemo extends Component {
             </MenuItem>
             <MenuItem
               itemId="group:storage"
-              icon={<StorageDomainIcon />}
+              icon={<RhUiStorageDomainFillIcon />}
               direction="down"
               drilldownMenu={
                 <DrilldownMenu id="drilldownMenuStorage">
-                  <MenuItem itemId="group:storage" icon={<StorageDomainIcon />} direction="up">
+                  <MenuItem itemId="group:storage" icon={<RhUiStorageDomainFillIcon />} direction="up">
                     Add storage
                   </MenuItem>
                   <Divider component="li" />
                   <MenuItem icon={<RhUiBranchFillIcon />} itemId="git">
                     From Git
                   </MenuItem>
-                  <MenuItem icon={<LayerGroupIcon />} itemId="container">
+                  <MenuItem icon={<RhUiServerStackFillIcon />} itemId="container">
                     Container Image
                   </MenuItem>
                   <MenuItem icon={<CubeIcon />} itemId="docker">


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #12399

This covers ServerIcon, StorageDomainIcon, and LayerGroupIcon

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated icons used in Alert, Menu (including drilldown), Tabs, and CustomMenus examples/demos to newer PatternFly variants. Replaced older server/storage/layer-group icons (and related imports) with `RhUiServerStackFillIcon` and `RhUiStorageDomainFillIcon` where appropriate. Also refreshed the Menu demo in the integration app to match. No component behavior or interactions changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->