### PR TITLE
fix(InfrastructureIcons): replaced with RH brand icons part 2

### DIFF
--- a/packages/react-core/src/components/Alert/examples/Alert.md
+++ b/packages/react-core/src/components/Alert/examples/Alert.md
@@ -12,7 +12,7 @@ import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-user
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
-import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
+import RhUiLaptopFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-laptop-fill-icon';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
 Micro animations have been added for `<Alert>` components within an `<AlertGroup>`. By default, you must opt into animations, since they can require updates to tests. To enable or disable animations as needed, use the `hasAnimations` property. With animations enabled, we recommend you ensure that dynamically-added alerts are prepended to a list of alerts, rather than appended to the end of it.

--- a/packages/react-core/src/components/Alert/examples/AlertCustomIcons.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertCustomIcons.tsx
@@ -4,7 +4,7 @@ import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-user
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
-import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
+import RhUiLaptopFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-laptop-fill-icon';
 
 export const AlertCustomIcons: React.FunctionComponent = () => (
   <Fragment>
@@ -12,6 +12,6 @@ export const AlertCustomIcons: React.FunctionComponent = () => (
     <Alert customIcon={<RhUiContainerFillIcon />} variant="info" title="Info alert title" />
     <Alert customIcon={<DatabaseIcon />} variant="success" title="Success alert title" />
     <Alert customIcon={<RhUiServerStackFillIcon />} variant="warning" title="Warning alert title" />
-    <Alert customIcon={<LaptopIcon />} variant="danger" title="Danger alert title" />
+    <Alert customIcon={<RhUiLaptopFillIcon />} variant="danger" title="Danger alert title" />
   </Fragment>
 );

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -6,45 +6,55 @@ propComponents: ['EmptyState', 'EmptyStateBody', 'EmptyStateFooter', 'EmptyState
 ---
 
 import { useState } from 'react';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 ## Examples
+
 ### Basic
 
 ```ts file="EmptyStateBasic.tsx"
+
 ```
 
 ### Extra small
 
 ```ts file="EmptyStateExtraSmall.tsx"
+
 ```
 
 ### Small
 
 ```ts file="EmptyStateSmall.tsx"
+
 ```
 
 ### Large
 
 ```ts file="EmptyStateLarge.tsx"
+
 ```
 
 ### Extra large
 
 ```ts file="EmptyStateExtraLarge.tsx"
+
 ```
 
 ### With status
+
 ```ts file="EmptyStateWithStatus.tsx"
+
 ```
 
 ### Spinner
 
 ```ts file="EmptyStateSpinner.tsx"
+
 ```
 
 ### No match found
 
 ```ts file="EmptyStateNoMatchFound.tsx"
+
 ```

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -8,6 +8,7 @@ propComponents: ['EmptyState', 'EmptyStateBody', 'EmptyStateFooter', 'EmptyState
 import { useState } from 'react';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
 import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 ## Examples
 

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateBasic.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateBasic.tsx
@@ -1,8 +1,8 @@
 import { Button, EmptyState, EmptyStateBody, EmptyStateActions, EmptyStateFooter } from '@patternfly/react-core';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 export const EmptyStateBasic: React.FunctionComponent = () => (
-  <EmptyState titleText="Empty state" headingLevel="h4" icon={CubesIcon}>
+  <EmptyState titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateBasic.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateBasic.tsx
@@ -1,8 +1,8 @@
 import { Button, EmptyState, EmptyStateBody, EmptyStateActions, EmptyStateFooter } from '@patternfly/react-core';
-import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 export const EmptyStateBasic: React.FunctionComponent = () => (
-  <EmptyState titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
+  <EmptyState titleText="Empty state" headingLevel="h4" icon={RhUiModuleIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraLarge.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraLarge.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 export const EmptyStateExtraLarge: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.xl} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
+  <EmptyState variant={EmptyStateVariant.xl} titleText="Empty state" headingLevel="h4" icon={RhUiModuleIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraLarge.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraLarge.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 export const EmptyStateExtraLarge: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.xl} titleText="Empty state" headingLevel="h4" icon={CubesIcon}>
+  <EmptyState variant={EmptyStateVariant.xl} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraSmall.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraSmall.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 export const EmptyStateExtraSmall: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.xs} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
+  <EmptyState variant={EmptyStateVariant.xs} titleText="Empty state" headingLevel="h4" icon={RhUiModuleIcon}>
     <EmptyStateBody>This represents an the empty state pattern in PatternFly. The icon is optional.</EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraSmall.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateExtraSmall.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 export const EmptyStateExtraSmall: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.xs} titleText="Empty state" headingLevel="h4" icon={CubesIcon}>
+  <EmptyState variant={EmptyStateVariant.xs} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
     <EmptyStateBody>This represents an the empty state pattern in PatternFly. The icon is optional.</EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateLarge.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateLarge.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 export const EmptyStateLarge: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.lg} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
+  <EmptyState variant={EmptyStateVariant.lg} titleText="Empty state" headingLevel="h4" icon={RhUiModuleIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateLarge.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateLarge.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 export const EmptyStateLarge: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.lg} titleText="Empty state" headingLevel="h4" icon={CubesIcon}>
+  <EmptyState variant={EmptyStateVariant.lg} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateSmall.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateSmall.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 export const EmptyStateSmall: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.sm} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
+  <EmptyState variant={EmptyStateVariant.sm} titleText="Empty state" headingLevel="h4" icon={RhUiModuleIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/EmptyState/examples/EmptyStateSmall.tsx
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyStateSmall.tsx
@@ -6,10 +6,10 @@ import {
   EmptyStateActions,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 export const EmptyStateSmall: React.FunctionComponent = () => (
-  <EmptyState variant={EmptyStateVariant.sm} titleText="Empty state" headingLevel="h4" icon={CubesIcon}>
+  <EmptyState variant={EmptyStateVariant.sm} titleText="Empty state" headingLevel="h4" icon={RhUiCubesIcon}>
     <EmptyStateBody>
       This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to
       meet a variety of needs.

--- a/packages/react-core/src/components/List/examples/List.md
+++ b/packages/react-core/src/components/List/examples/List.md
@@ -7,33 +7,48 @@ propComponents: ['List', 'ListItem']
 
 import RhUiLearnFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-learn-fill-icon';
 import RhUiKeyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-key-icon';
-import DesktopIcon from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
+import RhUiDesktopIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-desktop-icon';
 
 ## Examples
+
 ### Basic
+
 ```ts file="./ListBasic.tsx"
+
 ```
 
 ### Inline
+
 ```ts file="./ListInline.tsx"
+
 ```
 
 ### Ordered
+
 ```ts file="./ListOrdered.tsx"
+
 ```
 
 ### Plain
+
 ```ts file="./ListPlain.tsx"
+
 ```
 
 ### With horizontal rules
+
 ```ts file="./ListHorizontalRules.tsx"
+
 ```
 
 ### With icons
+
 ```ts file="./ListIcons.tsx"
+
 ```
 
 ### With large icons
+
 ```ts file="./ListLargeIcons.tsx"
+
 ```

--- a/packages/react-core/src/components/List/examples/ListIcons.tsx
+++ b/packages/react-core/src/components/List/examples/ListIcons.tsx
@@ -1,12 +1,12 @@
 import { List, ListItem } from '@patternfly/react-core';
 import RhUiLearnFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-learn-fill-icon';
 import RhUiKeyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-key-icon';
-import DesktopIcon from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
+import RhUiDesktopIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-desktop-icon';
 
 export const ListIcons: React.FunctionComponent = () => (
   <List isPlain>
     <ListItem icon={<RhUiLearnFillIcon />}>First</ListItem>
     <ListItem icon={<RhUiKeyIcon />}>Second</ListItem>
-    <ListItem icon={<DesktopIcon />}>Third</ListItem>
+    <ListItem icon={<RhUiDesktopIcon />}>Third</ListItem>
   </List>
 );

--- a/packages/react-core/src/components/List/examples/ListLargeIcons.tsx
+++ b/packages/react-core/src/components/List/examples/ListLargeIcons.tsx
@@ -1,12 +1,12 @@
 import { List, ListItem } from '@patternfly/react-core';
 import RhUiLearnFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-learn-fill-icon';
 import RhUiKeyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-key-icon';
-import DesktopIcon from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
+import RhUiDesktopIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-desktop-icon';
 
 export const ListLargeIcons: React.FunctionComponent = () => (
   <List isPlain iconSize="large">
     <ListItem icon={<RhUiLearnFillIcon />}>First</ListItem>
     <ListItem icon={<RhUiKeyIcon />}>Second</ListItem>
-    <ListItem icon={<DesktopIcon />}>Third</ListItem>
+    <ListItem icon={<RhUiDesktopIcon />}>Third</ListItem>
   </List>
 );

--- a/packages/react-core/src/components/Nav/examples/Nav.md
+++ b/packages/react-core/src/components/Nav/examples/Nav.md
@@ -12,7 +12,7 @@ import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-m
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiFolderOpenFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-open-fill-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-link-icon';
 
 ## Examples

--- a/packages/react-core/src/components/Nav/examples/NavIcons.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavIcons.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
 import RhUiFolderOpenFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-open-fill-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-link-icon';
 
 export const NavIcons: React.FunctionComponent = () => {
@@ -42,7 +42,7 @@ export const NavIcons: React.FunctionComponent = () => {
           to="#nav-icon-link3"
           itemId={2}
           isActive={activeItem === 2}
-          icon={<CloudIcon />}
+          icon={<RhUiCloudFillIcon />}
         >
           Link 3
         </NavItem>

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -22,7 +22,7 @@ import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-user
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
-import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
+import RhUiLaptopFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-laptop-fill-icon';
 import RhUiInfrastructureFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-infrastructure-fill-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';

--- a/packages/react-core/src/components/Tabs/examples/TabsIconAndText.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsIconAndText.tsx
@@ -4,7 +4,7 @@ import RhUiUsersFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-user
 import RhUiContainerFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-container-fill-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import RhUiServerStackFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-server-stack-fill-icon';
-import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
+import RhUiLaptopFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-laptop-fill-icon';
 import RhUiInfrastructureFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-infrastructure-fill-icon';
 
 export const TabsIconAndText: React.FunctionComponent = () => {
@@ -82,7 +82,7 @@ export const TabsIconAndText: React.FunctionComponent = () => {
         title={
           <>
             <TabTitleIcon>
-              <LaptopIcon />
+              <RhUiLaptopFillIcon />
             </TabTitleIcon>{' '}
             <TabTitleText>System</TabTitleText>{' '}
           </>

--- a/packages/react-core/src/demos/Compass/Compass.md
+++ b/packages/react-core/src/demos/Compass/Compass.md
@@ -11,7 +11,7 @@ import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/r
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
 import imgAvatar from '../assets/avatarImg.svg';

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -31,7 +31,7 @@ import {
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
 import pfLogo from '../../assets/PF-IconLogo-color.svg';
@@ -281,7 +281,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                       to="#nav-icon-link3"
                       itemId={2}
                       isActive={activeItem === 2}
-                      icon={<CloudIcon />}
+                      icon={<RhUiCloudFillIcon />}
                       anchorRef={navItem3Ref}
                       aria-label="Authentication"
                     >

--- a/packages/react-core/src/demos/Nav.md
+++ b/packages/react-core/src/demos/Nav.md
@@ -14,7 +14,7 @@ import imgAvatar from '@patternfly/react-core/src/components/assets/avatarImg.sv
 import pfLogo from '@patternfly/react-core/src/demos/assets/PF-HorizontalLogo-Color.svg';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhUiThumbnailViewSmallFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-thumbnail-view-small-fill-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';

--- a/packages/react-core/src/demos/Page.md
+++ b/packages/react-core/src/demos/Page.md
@@ -13,7 +13,7 @@ import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-
 import LightbulbIcon from '@patternfly/react-icons/dist/esm/icons/lightbulb-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import pfLogo from '@patternfly/react-core/src/demos/assets/PF-HorizontalLogo-Color.svg';
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';
 

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -33,7 +33,7 @@ import {
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
-import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
+import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhUiThumbnailViewSmallFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-thumbnail-view-small-fill-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
@@ -301,7 +301,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
                     to="#nav-link3"
                     itemId={2}
                     isActive={activeItem === 2}
-                    icon={<CloudIcon />}
+                    icon={<RhUiCloudFillIcon />}
                     anchorRef={navItem3Ref}
                     aria-label="Authentication"
                   >

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
@@ -10,7 +10,7 @@ import {
   EmptyStateVariant,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiModuleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-module-icon';
 
 class EmptyStateTable extends Component<TableProps, { columns: (ICell | string)[]; rows: IRow[] }> {
   static displayName = 'EmptyStateTable';
@@ -29,7 +29,7 @@ class EmptyStateTable extends Component<TableProps, { columns: (ICell | string)[
           heightAuto: true,
           props: { colSpan: '8' },
           title: (
-            <EmptyState headingLevel="h5" titleText="Empty state" icon={RhUiCubesIcon} variant={EmptyStateVariant.sm}>
+            <EmptyState headingLevel="h5" titleText="Empty state" icon={RhUiModuleIcon} variant={EmptyStateVariant.sm}>
               <EmptyStateBody>
                 This represents an the empty state pattern in Patternfly 4. Hopefully it's simple enough to use but
                 flexible enough to meet a variety of needs.

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
@@ -10,7 +10,7 @@ import {
   EmptyStateVariant,
   EmptyStateFooter
 } from '@patternfly/react-core';
-import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 
 class EmptyStateTable extends Component<TableProps, { columns: (ICell | string)[]; rows: IRow[] }> {
   static displayName = 'EmptyStateTable';
@@ -29,7 +29,7 @@ class EmptyStateTable extends Component<TableProps, { columns: (ICell | string)[
           heightAuto: true,
           props: { colSpan: '8' },
           title: (
-            <EmptyState headingLevel="h5" titleText="Empty state" icon={CubesIcon} variant={EmptyStateVariant.sm}>
+            <EmptyState headingLevel="h5" titleText="Empty state" icon={RhUiCubesIcon} variant={EmptyStateVariant.sm}>
               <EmptyStateBody>
                 This represents an the empty state pattern in Patternfly 4. Hopefully it's simple enough to use but
                 flexible enough to meet a variety of needs.


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #12399

Covers DesktopIcon, LaptopIcon, CloudIcon, and CubesIcon

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated component example and demo markdown for Alert, EmptyState, List, Nav, and Tabs to reference the latest icon components.
  * Refreshed Compass and Page demo documentation to align with the updated icon set.
* **Refactor**
  * Updated icons used throughout related example and demo UI (including Alert/EmptyState/List/Nav/Tabs and dock/navigation items) to the latest variants, keeping layout and behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->