### PR TITLE
fix(WarningTriangleIcon): Replace WarningTriangleIcon with RhUiWarningIcon

### DIFF
--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -7,7 +7,7 @@ ouia: true
 ---
 
 import { Fragment, useRef, useState } from 'react';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import RhUiAttentionBellFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-attention-bell-fill-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';

--- a/packages/react-core/src/components/Modal/examples/ModalCustomHeader.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalCustomHeader.tsx
@@ -12,7 +12,7 @@ import {
   Flex
 } from '@patternfly/react-core';
 
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 
 export const ModalCustomHeaderFooter: React.FunctionComponent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -55,7 +55,7 @@ export const ModalCustomHeaderFooter: React.FunctionComponent = () => {
         <ModalFooter>
           <Title headingLevel="h4" size={TitleSizes.md}>
             <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-              <WarningTriangleIcon />
+              <RhUiWarningIcon />
               <span>Custom modal footer.</span>
             </Flex>
           </Title>

--- a/packages/react-core/src/deprecated/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/deprecated/components/Modal/examples/Modal.md
@@ -10,7 +10,7 @@ deprecated: true
 import { Fragment, useRef, useState } from 'react';
 
 import { Modal as ModalDeprecated, ModalVariant as ModalVariantDeprecated } from '@patternfly/react-core/deprecated';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import RhUiAttentionBellFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-attention-bell-fill-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';

--- a/packages/react-core/src/deprecated/components/Modal/examples/ModalCustomHeaderFooter.tsx
+++ b/packages/react-core/src/deprecated/components/Modal/examples/ModalCustomHeaderFooter.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from 'react';
 import { Button, Title, TitleSizes } from '@patternfly/react-core';
 import { Modal as ModalDeprecated, ModalVariant as ModalVariantDeprecated } from '@patternfly/react-core/deprecated';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 export const ModalCustomHeaderFooter: React.FunctionComponent = () => {
@@ -22,7 +22,7 @@ export const ModalCustomHeaderFooter: React.FunctionComponent = () => {
 
   const footer = (
     <Title headingLevel="h4" size={TitleSizes.md}>
-      <WarningTriangleIcon />
+      <RhUiWarningIcon />
       <span className={spacing.plSm}>Custom modal footer.</span>
     </Title>
   );

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -9,7 +9,7 @@ import {
   Title,
   TitleSizes
 } from '@patternfly/react-core';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 interface ModalDemoState {
@@ -348,7 +348,7 @@ export class ModalDemo extends Component<React.HTMLProps<HTMLDivElement>, ModalD
         </ModalBody>
         <ModalFooter>
           <Title id="customFooterTitle" headingLevel="h4" size={TitleSizes.md}>
-            <WarningTriangleIcon />
+            <RhUiWarningIcon />
             <span className={spacing.plSm}>Custom modal footer.</span>
           </Title>
         </ModalFooter>

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDeprecatedDemo/ModalDeprecatedDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDeprecatedDemo/ModalDeprecatedDemo.tsx
@@ -1,7 +1,7 @@
 import { Component, Fragment } from 'react';
 import { Button, Title, TitleSizes } from '@patternfly/react-core';
 import { Modal as ModalDeprecated, ModalVariant as ModalVariantDeprecated } from '@patternfly/react-core/deprecated';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 interface ModalDemoState {
@@ -297,7 +297,7 @@ export class ModalDeprecatedDemo extends Component<React.HTMLProps<HTMLDivElemen
 
     const footer = (
       <Title id="customFooterTitle" headingLevel="h4" size={TitleSizes.md}>
-        <WarningTriangleIcon />
+        <RhUiWarningIcon />
         <span className={spacing.plSm}>Custom modal footer.</span>
       </Title>
     );


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
Part of https://github.com/patternfly/patternfly-react/issues/12402. Breaking into separate PRs so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the warning icon used in Modal custom header/footer examples and demos to improve visual consistency.
* **Documentation**
  * Refreshed Modal documentation examples to use the updated warning icon in import snippets and rendered examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->