### PR TITLE
fix(QuestionIcon): Replace QuestionIcon with RhUiQuestionMarkIcon

### DIFF
--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -7,7 +7,7 @@ propComponents: ['HelperText', 'HelperTextItem']
 
 import { Fragment } from 'react';
 import InfoIcon from '@patternfly/react-icons/dist/esm/icons/info-icon';
-import QuestionIcon from '@patternfly/react-icons/dist/esm/icons/question-icon';
+import RhUiQuestionMarkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-icon';
 import RhMicronsCheckmarkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-checkmark-icon';
 import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';

--- a/packages/react-core/src/components/HelperText/examples/HelperTextWithCustomIcon.tsx
+++ b/packages/react-core/src/components/HelperText/examples/HelperTextWithCustomIcon.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import InfoIcon from '@patternfly/react-icons/dist/esm/icons/info-icon';
-import QuestionIcon from '@patternfly/react-icons/dist/esm/icons/question-icon';
+import RhUiQuestionMarkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-icon';
 import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 import RhMicronsCheckmarkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-checkmark-icon';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
@@ -12,7 +12,7 @@ export const HelperTextWithCustomIcon: React.FunctionComponent = () => (
       <HelperTextItem icon={<InfoIcon />}>This is default helper text</HelperTextItem>
     </HelperText>
     <HelperText>
-      <HelperTextItem variant="indeterminate" icon={<QuestionIcon />}>
+      <HelperTextItem variant="indeterminate" icon={<RhUiQuestionMarkIcon />}>
         This is indeterminate helper text
       </HelperTextItem>
     </HelperText>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Part of https://github.com/patternfly/patternfly-react/issues/12402. Breaking into separate PRs so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated HelperText component examples to showcase an alternative icon option (switching to a question mark icon).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->