### PR TITLE
fix(CI): unblock Release workflow documentation job on main pushes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Check out project
         if: github.event_name == 'workflow_call'
         uses: actions/checkout@v4
-e
       - name: Set up and build project
         uses: ./.github/actions/setup-project
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,6 @@ on:
         required: true
 jobs:
   check-permissions:
-    if: github.event_name != 'workflow_call'
     uses: patternfly/.github/.github/workflows/check-team-membership.yml@fdb52a63a2220ec8a3b6c2d43f312cda708ffa06
     secrets: inherit
 
@@ -42,7 +41,7 @@ jobs:
       - name: Check out project
         if: github.event_name == 'workflow_call'
         uses: actions/checkout@v4
-
+e
       - name: Set up and build project
         uses: ./.github/actions/setup-project
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,6 +13,7 @@ on:
         required: true
 jobs:
   check-permissions:
+    if: github.event_name != 'workflow_call'
     uses: patternfly/.github/.github/workflows/check-team-membership.yml@fdb52a63a2220ec8a3b6c2d43f312cda708ffa06
     secrets: inherit
 
@@ -20,7 +21,10 @@ jobs:
     name: Build, test & deploy
     runs-on: ubuntu-latest
     needs: check-permissions
-    if: github.event_name == 'workflow_call' || needs.check-permissions.outputs.allowed == 'true'
+    if: >-
+      always() &&
+      !cancelled() &&
+      (github.event_name == 'workflow_call' || needs.check-permissions.outputs.allowed == 'true')
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
## Summary

- Skip the `check-permissions` job on `workflow_call` events (Release pushes to `main`), since the org `check-team-membership` reusable workflow only runs for PR preview events
- Update the `deploy` job condition to use `always() && !cancelled()` so it still runs when `check-permissions` is skipped, unblocking the Release workflow's `Deploy release` job and NPM publishes

Fixes the skipped Documentation and Deploy release jobs seen in [Release run #3125](https://github.com/patternfly/patternfly-react/actions/runs/28045886499).

## Test plan

- [ ] Merge this PR and verify the next push to `main` runs `Documentation / Build, test & deploy` and `Deploy release` instead of skipping them
- [ ] Open a PR from a non-team member and confirm documentation preview deploy is still gated behind the team membership check
- [ ] Comment `/deploy-preview` on a PR from a team member and confirm preview deploy still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration/deployment workflow to strengthen deployment eligibility checks, adding additional execution safeguards to help prevent unintended or incomplete deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->