### PR TITLE
fix(TimesCircleIcon): Replace TimesCircleIcon with RhUiCloseCircleFillIcon

### DIFF
--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatus.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatus.tsx
@@ -5,7 +5,7 @@ import { ExpandableSection } from '../ExpandableSection';
 import { useSSRSafeId } from '../../helpers';
 import RhUiInProgressIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-in-progress-icon';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
-import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+import RhUiCloseCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-close-circle-fill-icon';
 
 /** Acts as an expandable container for all uploaded file statuses.
  * An optional text and/or icon can also be passed into this sub-component.
@@ -41,7 +41,7 @@ export const MultipleFileUploadStatus: React.FunctionComponent<MultipleFileUploa
   useEffect(() => {
     switch (statusToggleIcon) {
       case 'danger':
-        setIcon(<TimesCircleIcon />);
+        setIcon(<RhUiCloseCircleFillIcon />);
         break;
       case 'success':
         setIcon(<RhUiCheckCircleFillIcon />);

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -12,7 +12,7 @@ import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-u
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
-import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+import RhUiCloseCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-close-circle-fill-icon';
 import pfIcon from './assets/pf-logo-small.svg';
 import activeMQIcon from './assets/activemq-core_200x150.png';
 import avroIcon from './assets/camel-avro_200x150.png';

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailContentPadding.tsx
@@ -46,7 +46,7 @@ import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-u
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
-import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+import RhUiCloseCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-close-circle-fill-icon';
 
 interface SelectOptionType extends Omit<SelectOptionProps, 'children'> {
   label: string;
@@ -293,7 +293,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                         <RhUiWarningFillIcon /> 5
                       </FlexItem>
                       <FlexItem>
-                        <TimesCircleIcon /> 5
+                        <RhUiCloseCircleFillIcon /> 5
                       </FlexItem>
                       <FlexItem>Updated 2 days ago</FlexItem>
                     </Flex>
@@ -390,7 +390,7 @@ export const PrimaryDetailContentPadding: React.FunctionComponent = () => {
                         <RhUiWarningFillIcon /> 5
                       </FlexItem>
                       <FlexItem>
-                        <TimesCircleIcon /> 5
+                        <RhUiCloseCircleFillIcon /> 5
                       </FlexItem>
                       <FlexItem>Updated 2 days ago</FlexItem>
                     </Flex>

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailFullPage.tsx
@@ -46,7 +46,7 @@ import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-u
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
-import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+import RhUiCloseCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-close-circle-fill-icon';
 
 interface SelectOptionType extends Omit<SelectOptionProps, 'children'> {
   label: string;
@@ -293,7 +293,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                         <RhUiWarningFillIcon /> 5
                       </FlexItem>
                       <FlexItem>
-                        <TimesCircleIcon /> 5
+                        <RhUiCloseCircleFillIcon /> 5
                       </FlexItem>
                       <FlexItem>Updated 2 days ago</FlexItem>
                     </Flex>
@@ -390,7 +390,7 @@ export const PrimaryDetailFullPage: React.FunctionComponent = () => {
                         <RhUiWarningFillIcon /> 5
                       </FlexItem>
                       <FlexItem>
-                        <TimesCircleIcon /> 5
+                        <RhUiCloseCircleFillIcon /> 5
                       </FlexItem>
                       <FlexItem>Updated 2 days ago</FlexItem>
                     </Flex>

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailInlineModifier.tsx
@@ -46,7 +46,7 @@ import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-u
 import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-fill-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
-import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+import RhUiCloseCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-close-circle-fill-icon';
 
 interface SelectOptionType extends Omit<SelectOptionProps, 'children'> {
   label: string;
@@ -293,7 +293,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                         <RhUiWarningFillIcon /> 5
                       </FlexItem>
                       <FlexItem>
-                        <TimesCircleIcon /> 5
+                        <RhUiCloseCircleFillIcon /> 5
                       </FlexItem>
                       <FlexItem>Updated 2 days ago</FlexItem>
                     </Flex>
@@ -390,7 +390,7 @@ export const PrimaryDetailInlineModifier: React.FunctionComponent = () => {
                         <RhUiWarningFillIcon /> 5
                       </FlexItem>
                       <FlexItem>
-                        <TimesCircleIcon /> 5
+                        <RhUiCloseCircleFillIcon /> 5
                       </FlexItem>
                       <FlexItem>Updated 2 days ago</FlexItem>
                     </Flex>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Part of https://github.com/patternfly/patternfly-react/issues/12402. Breaking into separate PRs so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated status indicator and warning/error icons across file upload components and Primary Detail demos. The “danger” and related warning/error states now use the close-circle filled icon instead of the previous times-circle icon, aligning visuals with the design system for more consistent UI feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->