### PR TITLE
fix(PauseIcon): Replace PauseIcon with RhUiPauseFillIcon

### DIFF
--- a/packages/react-core/src/demos/Toolbar.md
+++ b/packages/react-core/src/demos/Toolbar.md
@@ -4,7 +4,7 @@ section: components
 ---
 
 import { Fragment, useState } from 'react';
-import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
+import RhUiPauseFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-pause-fill-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';

--- a/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
+++ b/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
@@ -20,7 +20,7 @@ import {
   MenuFooter
 } from '@patternfly/react-core';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
-import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
+import RhUiPauseFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-pause-fill-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
@@ -313,7 +313,7 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
         <Button
           variant={isPaused ? 'plain' : 'link'}
           onClick={pauseOrStart}
-          icon={isPaused ? <PlayIcon /> : <PauseIcon />}
+          icon={isPaused ? <PlayIcon /> : <RhUiPauseFillIcon />}
         >
           {isPaused ? ` Resume Log` : ` Pause Log`}
         </Button>
@@ -370,7 +370,7 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
             variant="plain"
             onClick={pauseOrStart}
             aria-label={isPaused ? 'Play' : 'Paused'}
-            icon={isPaused ? <PlayIcon /> : <PauseIcon />}
+            icon={isPaused ? <PlayIcon /> : <RhUiPauseFillIcon />}
           />
         </Tooltip>
       </ToolbarItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Part of https://github.com/patternfly/patternfly-react/issues/12402. Breaking into separate PRs so it is easier to review.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the pause icon in the console log viewer toolbar to use the latest design system icon across desktop and mobile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->