### PR TITLE
fix(LongArrowAltDown/UpIcon): Replace with microns versions

### DIFF
--- a/packages/react-core/src/components/Icon/examples/Icon.md
+++ b/packages/react-core/src/components/Icon/examples/Icon.md
@@ -6,7 +6,7 @@ propComponents: ['Icon']
 ---
 
 import { Fragment, useState } from 'react';
-import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
+import RhMicronsArrowDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-arrow-down-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';

--- a/packages/react-core/src/components/Icon/examples/IconBasic.tsx
+++ b/packages/react-core/src/components/Icon/examples/IconBasic.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { Icon } from '@patternfly/react-core';
-import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
+import RhMicronsArrowDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-arrow-down-icon';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
 import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-settings-fill-icon';
@@ -8,7 +8,7 @@ import RhUiSettingsFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-s
 export const IconBasic: React.FunctionComponent = () => (
   <Fragment>
     <Icon>
-      <LongArrowAltDownIcon />
+      <RhMicronsArrowDownIcon />
     </Icon>{' '}
     <Icon>
       <RhMicronsCaretRightIcon />

--- a/packages/react-table/src/components/Table/SortColumn.tsx
+++ b/packages/react-table/src/components/Table/SortColumn.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import LongArrowAltUpIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-up-icon';
-import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
+import RhMicronsArrowUpIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-arrow-up-icon';
+import RhMicronsArrowDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-arrow-down-icon';
 import ArrowsAltVIcon from '@patternfly/react-icons/dist/esm/icons/arrows-alt-v-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
@@ -43,7 +43,7 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   let SortedByIcon;
   const [focused, setFocused] = useState(false);
   if (isSortedBy) {
-    SortedByIcon = sortDirection === SortByDirection.asc ? LongArrowAltUpIcon : LongArrowAltDownIcon;
+    SortedByIcon = sortDirection === SortByDirection.asc ? RhMicronsArrowUpIcon : RhMicronsArrowDownIcon;
   } else {
     SortedByIcon = ArrowsAltVIcon;
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Part of https://github.com/patternfly/patternfly-react/issues/12402. Breaking into separate PRs so it is easier to review. I know this one is tiny but others are large.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style
- Updated the down-arrow and up-arrow icons used in table sorting to a refreshed “RhMicrons” arrow set.
- Updated Icon component examples to use the matching “RhMicrons” down-arrow icon.

## Documentation
- Refreshed the Icon examples documentation to reflect the new “RhMicrons” arrow icon import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->