### PR TITLE
fix(table): updated nested sticky header example with isBorderRow tr

### DIFF
--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -452,6 +452,7 @@ To make a nested column header:
 2. Pass `nestedHeaderColumnSpans` to `Table`. `nestedHeaderColumnSpans` is an array of numbers representing the column spans of the top level columns to `Table`, where each number is equal to the number of sub columns for a column, or `1` if a column contains no sub columns.
 3. Pass `hasNestedHeader` to `Thead`.
 4. Pass two `Tr` as children of `Thead`.
+5. If the parent `Table` has a sticky header, pass an additional `Tr isBorderRow` in `Thead` to create the bottom border in the `Thead`.
 
 The first `Tr` represents the top level of columns, and each must pass either `rowSpan` if the column does not contain sub columns or `colSpan` if the column contains sub columns. The value of `rowSpan` is equal to the number of rows the nested header will span, typically `2`, and the value of `colSpan` is equal to the number of sub columns in a column. Each `Th` except the last should also pass `hasRightBorder`.
 

--- a/packages/react-table/src/components/Table/examples/TableNestedStickyHeader.tsx
+++ b/packages/react-table/src/components/Table/examples/TableNestedStickyHeader.tsx
@@ -161,7 +161,7 @@ export const TableNestedHeaders: React.FunctionComponent = () => {
             {sortedConnections.map((connection) => (
               <Tr key={connection.source.podName}>
                 <Td dataLabel={columnNames.source}>{connection.source.podName}</Td>
-                <Td dataLabel={columnNames.destination}>{connection.destination.podName}</Td>\
+                <Td dataLabel={columnNames.destination}>{connection.destination.podName}</Td>
                 <Td dataLabel={columnNames.datetime}>
                   <div>
                     <Timestamp dateFormat="full" timeFormat="medium" date={new Date(connection.timestamp)} />

--- a/packages/react-table/src/components/Table/examples/TableNestedStickyHeader.tsx
+++ b/packages/react-table/src/components/Table/examples/TableNestedStickyHeader.tsx
@@ -112,85 +112,90 @@ export const TableNestedHeaders: React.FunctionComponent = () => {
   });
 
   return (
-    <InnerScrollContainer>
-      <Table aria-label="Nested column headers table" gridBreakPoint="" isStickyHeader>
-        <Thead hasNestedHeader>
-          <Tr>
-            <Th hasRightBorder colSpan={3}>
-              {columnNames.pods}
-            </Th>
-            <Th hasRightBorder colSpan={2}>
-              {columnNames.ports}
-            </Th>
-            <Th modifier="fitContent" hasRightBorder rowSpan={2} sort={getSortParams(5)}>
-              {columnNames.protocol}
-            </Th>
-            <Th modifier="fitContent" hasRightBorder rowSpan={2} sort={getSortParams(6)}>
-              {columnNames.flowRate}
-            </Th>
-            <Th modifier="fitContent" hasRightBorder rowSpan={2} sort={getSortParams(7)}>
-              {columnNames.traffic}
-            </Th>
-            <Th modifier="fitContent" rowSpan={2} sort={getSortParams(8)}>
-              {columnNames.packets}
-            </Th>
-          </Tr>
-          <Tr>
-            <Th isSubheader sort={getSortParams(0)}>
-              {columnNames.source}
-            </Th>
-            <Th isSubheader sort={getSortParams(1)}>
-              {columnNames.destination}
-            </Th>
-            <Th isSubheader modifier="fitContent" hasRightBorder sort={getSortParams(2)}>
-              {columnNames.datetime}
-            </Th>
-            <Th isSubheader modifier="fitContent" sort={getSortParams(3)}>
-              {columnNames.source}
-            </Th>
-            <Th isSubheader modifier="fitContent" hasRightBorder sort={getSortParams(4)}>
-              {columnNames.destination}
-            </Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {sortedConnections.map((connection) => (
-            <Tr key={connection.source.podName}>
-              <Td dataLabel={columnNames.source}>{connection.source.podName}</Td>
-              <Td dataLabel={columnNames.destination}>{connection.destination.podName}</Td>\
-              <Td dataLabel={columnNames.datetime}>
-                <div>
-                  <Timestamp dateFormat="full" timeFormat="medium" date={new Date(connection.timestamp)} />
-                </div>
-              </Td>
-              <Td dataLabel={columnNames.source}>
-                <Stack>
-                  <StackItem>
-                    <span>{connection.source.port.num}</span>
-                  </StackItem>
-                  <StackItem>
-                    <small>({connection.source.port.protocol})</small>
-                  </StackItem>
-                </Stack>
-              </Td>
-              <Td dataLabel={columnNames.destination}>
-                <Stack>
-                  <StackItem>
-                    <span>{connection.destination.port.num}</span>
-                  </StackItem>
-                  <StackItem>
-                    <small>({connection.destination.port.protocol})</small>
-                  </StackItem>
-                </Stack>
-              </Td>
-              <Td dataLabel={columnNames.protocol}>{connection.protocol}</Td>
-              <Td dataLabel={columnNames.flowRate}>{connection.flowRate}</Td>
-              <Td dataLabel={columnNames.traffic}>{connection.traffic}</Td>
-              <Td dataLabel={columnNames.packets}>{connection.packets}</Td>
+    <div style={{ height: '250px' }}>
+      <InnerScrollContainer>
+        <Table aria-label="Nested column headers table" gridBreakPoint="" isStickyHeader>
+          <Thead hasNestedHeader>
+            <Tr>
+              <Th hasRightBorder colSpan={3}>
+                {columnNames.pods}
+              </Th>
+              <Th hasRightBorder colSpan={2}>
+                {columnNames.ports}
+              </Th>
+              <Th modifier="fitContent" hasRightBorder rowSpan={2} sort={getSortParams(5)}>
+                {columnNames.protocol}
+              </Th>
+              <Th modifier="fitContent" hasRightBorder rowSpan={2} sort={getSortParams(6)}>
+                {columnNames.flowRate}
+              </Th>
+              <Th modifier="fitContent" hasRightBorder rowSpan={2} sort={getSortParams(7)}>
+                {columnNames.traffic}
+              </Th>
+              <Th modifier="fitContent" rowSpan={2} sort={getSortParams(8)}>
+                {columnNames.packets}
+              </Th>
             </Tr>
-          ))}
-        </Tbody>
-      </Table>
-    </InnerScrollContainer>
+            <Tr>
+              <Th isSubheader sort={getSortParams(0)}>
+                {columnNames.source}
+              </Th>
+              <Th isSubheader sort={getSortParams(1)}>
+                {columnNames.destination}
+              </Th>
+              <Th isSubheader modifier="fitContent" hasRightBorder sort={getSortParams(2)}>
+                {columnNames.datetime}
+              </Th>
+              <Th isSubheader modifier="fitContent" sort={getSortParams(3)}>
+                {columnNames.source}
+              </Th>
+              <Th isSubheader modifier="fitContent" hasRightBorder sort={getSortParams(4)}>
+                {columnNames.destination}
+              </Th>
+            </Tr>
+            <Tr isBorderRow aria-hidden="true">
+              <Td colSpan={9}></Td>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {sortedConnections.map((connection) => (
+              <Tr key={connection.source.podName}>
+                <Td dataLabel={columnNames.source}>{connection.source.podName}</Td>
+                <Td dataLabel={columnNames.destination}>{connection.destination.podName}</Td>\
+                <Td dataLabel={columnNames.datetime}>
+                  <div>
+                    <Timestamp dateFormat="full" timeFormat="medium" date={new Date(connection.timestamp)} />
+                  </div>
+                </Td>
+                <Td dataLabel={columnNames.source}>
+                  <Stack>
+                    <StackItem>
+                      <span>{connection.source.port.num}</span>
+                    </StackItem>
+                    <StackItem>
+                      <small>({connection.source.port.protocol})</small>
+                    </StackItem>
+                  </Stack>
+                </Td>
+                <Td dataLabel={columnNames.destination}>
+                  <Stack>
+                    <StackItem>
+                      <span>{connection.destination.port.num}</span>
+                    </StackItem>
+                    <StackItem>
+                      <small>({connection.destination.port.protocol})</small>
+                    </StackItem>
+                  </Stack>
+                </Td>
+                <Td dataLabel={columnNames.protocol}>{connection.protocol}</Td>
+                <Td dataLabel={columnNames.flowRate}>{connection.flowRate}</Td>
+                <Td dataLabel={columnNames.traffic}>{connection.traffic}</Td>
+                <Td dataLabel={columnNames.packets}>{connection.packets}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </InnerScrollContainer>
+    </div>
   );
 };


### PR DESCRIPTION
Updates the nested sticky header docs and example to have `<Tr isBorderRow>`, which is required for sticky, nested column header tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a note in the nested column headers guide explaining that when the table uses a sticky header, the header section needs an extra row to keep the bottom border visible.

* **Bug Fixes**
  * Updated the nested sticky header example to render correctly inside a fixed-height container, improving scrolling and sticky header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->