### PR TITLE
fix(CodeEditor): Adjust sizeToFit height bug

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -386,6 +386,9 @@ export const CodeEditor = ({
     editorRef.current = editor;
     if (height === 'sizeToFit') {
       setHeightToFitContent();
+      editor.onDidContentSizeChange(() => {
+        setHeightToFitContent();
+      });
     }
   };
 

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -385,7 +385,6 @@ export const CodeEditor = ({
     onEditorDidMount(editor, monaco);
     editorRef.current = editor;
     if (height === 'sizeToFit') {
-      setHeightToFitContent();
       editor.onDidContentSizeChange(() => {
         setHeightToFitContent();
       });


### PR DESCRIPTION
I think this addresses the issue?

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/12436

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the editor’s auto-sizing behavior so it now updates height automatically as content changes when set to fit content.
  * This prevents the editor from staying at an outdated height after text is added or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->