### PR TITLE
feat(workspace): add tsconfig for examples

### DIFF
--- a/packages/tsconfig.examples.json
+++ b/packages/tsconfig.examples.json
@@ -1,10 +1,17 @@
 {
-  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true,
-    "composite": false,
-    "declarationMap": false
+    "jsx": "react-jsx",
+    "lib": ["es2015", "dom"],
+    "target": "es2015",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": false,
+    "isolatedModules": true,
+    "noEmit": true
   },
-  "include": ["**/examples/**/*.tsx", "**/demos/examples/**/*.tsx"],
+  "include": ["**/examples/**/*.tsx"],
   "exclude": ["**/**.test.tsx", "**/**.test.ts", "**/__mocks__/**"]
 }

--- a/packages/tsconfig.examples.json
+++ b/packages/tsconfig.examples.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declarationMap": false
+  },
+  "include": ["**/examples/**/*.tsx", "**/demos/examples/**/*.tsx"],
+  "exclude": ["**/**.test.tsx", "**/**.test.ts", "**/__mocks__/**"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "files": [],
-  "references": [{ "path": "./packages/tsconfig.json" }, { "path": "./packages/tsconfig.examples.json" }]
+  "extends": "./packages/tsconfig.examples.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./packages/tsconfig.json" }, { "path": "./packages/tsconfig.examples.json" }]
+}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12333

- Adds a tsconfig for example files to be properly evaluated with "react-jsx" (the default "react" reports out the false error with missing React).
- Adds a root tsconfig to assist the IDE in discovering the proper tsconfig. This may not be necessary but the examples config alone wasn't getting detected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript project setup for example/demo code so it is type-checked consistently during development.
  * Added a dedicated TypeScript configuration for React JSX examples, with emission disabled and tests/mocks excluded.
  * Simplified the root TypeScript configuration to extend the new example/demo setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->