### PR TITLE
fix(ci): fetch full git history in Promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Check out project
         uses: actions/checkout@v4
         with:
+          # Fetch all history for all branches and tags, which is needed for the release script.
+          fetch-depth: 0
           # Pass in an administrator token to get around branch protection.
           token: ${{ secrets.GH_TOKEN_REDALLEN }}
 


### PR DESCRIPTION
## Summary
- Adds `fetch-depth: 0` to the Promote workflow checkout step so Lerna can access git tags during `--conventional-graduate` publish
- Matches the existing Release workflow configuration, which already fetches full history for the same reason

## Context
The Promote workflow failed with `fatal: bad revision 'undefined'` because the default shallow checkout does not include git tags. Lerna needs those tags to determine which packages changed since their last release when graduating prerelease versions to stable.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the Promote workflow on `main`
- [ ] Confirm the deploy step completes without the Lerna git revision error


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to ensure it has access to complete project history during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->