### PR TITLE
fix(Wizard): add useEffect import

### DIFF
--- a/packages/react-core/src/deprecated/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/deprecated/components/Wizard/examples/Wizard.md
@@ -16,6 +16,8 @@ import { Wizard as WizardDeprecated, WizardFooter as WizardFooterDeprecated, Wiz
 import RhMicronsExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-external-link-icon';
 import SlackHashIcon from '@patternfly/react-icons/dist/esm/icons/slack-hash-icon';
 import RhUiGearGroupFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-gear-group-fill-icon';
+import CogsIcon from '@patternfly/react-icons/dist/esm/icons/cogs-icon';
+import layout from '@patternfly/react-styles/css/layouts/Bullseye/bullseye';
 
 If you seek a wizard solution that allows for more composition, see the [React](/components/wizard) tab.
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:

1.  Fix for Wizard Progress after submission so it doesn't fail on `useEffect` https://www.patternfly.org/components/wizard#progress-after-submission
2. Fix for deprecated Wizard Finish so it doesn't fail on not-imported `layout` https://www.patternfly.org/components/wizard/react-deprecated/#finished

Closes #12537



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Wizard example documentation to include additional icon and layout resources for richer example rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->