### PR TITLE
chore(menu toggle): fix avatar sizing

### DIFF
--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleAvatarText.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleAvatarText.tsx
@@ -4,11 +4,11 @@ import imgAvatar from '@patternfly/react-core/src/components/assets/avatarImg.sv
 
 export const MenuToggleAvatarText: React.FunctionComponent = () => (
   <Fragment>
-    <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" />}>Ned Username</MenuToggle>{' '}
-    <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" />} isExpanded>
+    <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" size="sm" />}>Ned Username</MenuToggle>{' '}
+    <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" size="sm" />} isExpanded>
       Ned Username
     </MenuToggle>{' '}
-    <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" />} isDisabled>
+    <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" size="sm" />} isDisabled>
       Ned Username
     </MenuToggle>
   </Fragment>


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/PF-4383

This PR is a small update to apply a size to the avatars inside the menu toggles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the menu toggle example to use a smaller avatar icon consistently across all states.
  * Adjusted formatting and line breaks in the example for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->