### PR TITLE
fix(readme): update broken Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This project provides a set of React components for the [PatternFly project](https://patternfly.org).  
 
-**Community:** [PatternFly website](https://www.patternfly.org) | [Slack](https://slack.patternfly.org) | [Medium](https://medium.com/patternfly) | [Mailing list](https://www.redhat.com/mailman/listinfo/patternfly)
+**Community:** [PatternFly website](https://www.patternfly.org) | [Slack](https://patternfly.slack.com) | [Medium](https://medium.com/patternfly) | [Mailing list](https://www.redhat.com/mailman/listinfo/patternfly)
   
 ### Table of contents
 1. [PatternFly React packages](#patternfly-react-packages)


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12546, replaced `https://slack.patternfly.org` with `https://patternfly.slack.com`
in the README, matching the fix applied in patternfly-org#3364.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: patternfly-org#3364 (previous fix in the docs site)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
* **Documentation**
  * Updated the Community Slack link in the README to the new workspace URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->