### PR TITLE
feat(Modal,Backdrop): Add opt-in animation support

### DIFF
--- a/packages/react-core/src/components/Backdrop/Backdrop.tsx
+++ b/packages/react-core/src/components/Backdrop/Backdrop.tsx
@@ -1,19 +1,35 @@
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Backdrop/backdrop';
+import stylesAnimated from '@patternfly/react-styles/css/components/BackdropAnimations/backdrop-animations';
 
 export interface BackdropProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the backdrop */
   children?: React.ReactNode;
   /** Additional classes added to the backdrop */
   className?: string;
+  /** Whether the Backdrop should open/close with animations. (BETA) */
+  animated?: boolean;
+  /** Flag to show the backdrop. Used in conjunction with `animated` (BETA) */
+  isVisible?: boolean;
 }
 
 export const Backdrop: React.FunctionComponent<BackdropProps> = ({
   children = null,
   className = '',
+  animated,
+  isVisible,
   ...props
 }: BackdropProps) => (
-  <div {...props} className={css(styles.backdrop, className)}>
+  <div
+    {...props}
+    className={css(
+      styles.backdrop,
+      animated && stylesAnimated.backdropAnimated,
+      animated && isVisible === true && stylesAnimated.backdropAnimatedVisible,
+      animated && isVisible !== true && stylesAnimated.backdropAnimatedHidden,
+      className
+    )}
+  >
     {children}
   </div>
 );

--- a/packages/react-core/src/components/Backdrop/Backdrop.tsx
+++ b/packages/react-core/src/components/Backdrop/Backdrop.tsx
@@ -1,36 +1,41 @@
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Backdrop/backdrop';
 import stylesAnimated from '@patternfly/react-styles/css/components/BackdropAnimations/backdrop-animations';
+import { useHasAnimations } from '../../helpers';
 
 export interface BackdropProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the backdrop */
   children?: React.ReactNode;
   /** Additional classes added to the backdrop */
   className?: string;
-  /** Whether the Backdrop should open/close with animations. (BETA) */
-  animated?: boolean;
-  /** Flag to show the backdrop. Used in conjunction with `animated` (BETA) */
+  /** Flag indicating whether animations are enabled. */
+  hasAnimations?: boolean;
+  /** Flag to show the backdrop. Used in conjunction with `hasAnimations`. */
   isVisible?: boolean;
 }
 
 export const Backdrop: React.FunctionComponent<BackdropProps> = ({
   children = null,
   className = '',
-  animated,
+  hasAnimations: hasAnimationsProp,
   isVisible,
   ...props
-}: BackdropProps) => (
-  <div
-    {...props}
-    className={css(
-      styles.backdrop,
-      animated && stylesAnimated.backdropAnimated,
-      animated && isVisible === true && stylesAnimated.backdropAnimatedVisible,
-      animated && isVisible !== true && stylesAnimated.backdropAnimatedHidden,
-      className
-    )}
-  >
-    {children}
-  </div>
-);
+}: BackdropProps) => {
+  const hasAnimations = useHasAnimations(hasAnimationsProp);
+
+  return (
+    <div
+      {...props}
+      className={css(
+        styles.backdrop,
+        hasAnimations && stylesAnimated.backdropAnimated,
+        hasAnimations && isVisible === true && stylesAnimated.backdropAnimatedVisible,
+        hasAnimations && isVisible !== true && stylesAnimated.backdropAnimatedHidden,
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+};
 Backdrop.displayName = 'Backdrop';

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -53,6 +53,8 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
   ouiaSafe?: boolean;
+  /** Whether the Modal should open/close with animations. (BETA) */
+  animated?: boolean;
 }
 
 export enum ModalVariant {

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -53,8 +53,8 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
   ouiaSafe?: boolean;
-  /** Whether the Modal should open/close with animations. (BETA) */
-  animated?: boolean;
+  /** Flag indicating whether animations are enabled. */
+  hasAnimations?: boolean;
 }
 
 export enum ModalVariant {

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -1,5 +1,6 @@
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/ModalBox/modal-box';
+import stylesAnimated from '@patternfly/react-styles/css/components/ModalAnimations/modal-animations';
 import topSpacer from '@patternfly/react-tokens/dist/esm/c_modal_box_m_align_top_spacer';
 
 export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
@@ -19,6 +20,10 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   positionOffset?: string;
   /** Variant of the modal. */
   variant?: 'small' | 'medium' | 'large' | 'default';
+  /** Whether the Modal should open/close with animations. (BETA) */
+  animated?: boolean;
+  /** Flag to show the modal. */
+  isOpen?: boolean;
 }
 
 export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
@@ -31,6 +36,8 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   'aria-label': ariaLabel,
   'aria-describedby': ariaDescribedby,
   style,
+  isOpen,
+  animated,
   ...props
 }: ModalBoxProps) => {
   if (positionOffset) {
@@ -46,6 +53,9 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
       aria-modal="true"
       className={css(
         styles.modalBox,
+        animated && stylesAnimated.modalAnimated,
+        animated && isOpen === true && stylesAnimated.modalAnimatedOpen,
+        animated && isOpen !== true && stylesAnimated.modalAnimatedClosed,
         className,
         position === 'top' && styles.modifiers.alignTop,
         variant === 'large' && styles.modifiers.lg,

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -20,8 +20,8 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   positionOffset?: string;
   /** Variant of the modal. */
   variant?: 'small' | 'medium' | 'large' | 'default';
-  /** Whether the Modal should open/close with animations. (BETA) */
-  animated?: boolean;
+  /** Flag indicating whether animations are enabled. */
+  hasAnimations?: boolean;
   /** Flag to show the modal. */
   isOpen?: boolean;
 }
@@ -37,7 +37,7 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   'aria-describedby': ariaDescribedby,
   style,
   isOpen,
-  animated,
+  hasAnimations,
   ...props
 }: ModalBoxProps) => {
   if (positionOffset) {
@@ -53,9 +53,9 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
       aria-modal="true"
       className={css(
         styles.modalBox,
-        animated && stylesAnimated.modalAnimated,
-        animated && isOpen === true && stylesAnimated.modalAnimatedOpen,
-        animated && isOpen !== true && stylesAnimated.modalAnimatedClosed,
+        hasAnimations && stylesAnimated.modalAnimated,
+        hasAnimations && isOpen === true && stylesAnimated.modalAnimatedOpen,
+        hasAnimations && isOpen !== true && stylesAnimated.modalAnimatedClosed,
         className,
         position === 'top' && styles.modifiers.alignTop,
         variant === 'large' && styles.modifiers.lg,

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -49,6 +49,8 @@ export interface ModalContentProps extends OUIAProps {
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
   ouiaSafe?: boolean;
+  /** Whether the Modal should open/close with animations. (BETA) */
+  animated?: boolean;
 }
 
 export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
@@ -72,9 +74,10 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   ouiaSafe = true,
   elementToFocus,
   focusTrapId,
+  animated,
   ...props
 }: ModalContentProps) => {
-  if (!isOpen) {
+  if (!isOpen && !animated) {
     return null;
   }
 
@@ -91,6 +94,8 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   const modalBox = (
     <ModalBox
       className={css(className)}
+      isOpen={isOpen}
+      animated={animated}
       variant={variant}
       position={position}
       positionOffset={positionOffset}
@@ -113,10 +118,15 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       {children}
     </ModalBox>
   );
+  let focusTrapActive = !disableFocusTrap;
+  if (animated) {
+    focusTrapActive = !disableFocusTrap && isOpen;
+  }
+
   return (
-    <Backdrop className={css(backdropClassName)} id={backdropId}>
+    <Backdrop className={css(backdropClassName)} id={backdropId} animated={animated} isVisible={isOpen}>
       <FocusTrap
-        active={!disableFocusTrap}
+        active={focusTrapActive}
         focusTrapOptions={{
           clickOutsideDeactivates: true,
           tabbableOptions: { displayCheck: 'none' },

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -1,7 +1,7 @@
 import { FocusTrap } from '../../helpers';
 import bullsEyeStyles from '@patternfly/react-styles/css/layouts/Bullseye/bullseye';
 import { css } from '@patternfly/react-styles';
-import { getOUIAProps, OUIAProps } from '../../helpers';
+import { getOUIAProps, OUIAProps, useHasAnimations } from '../../helpers';
 import { Backdrop } from '../Backdrop';
 import { ModalBoxCloseButton } from './ModalBoxCloseButton';
 import { ModalBox } from './ModalBox';
@@ -49,8 +49,8 @@ export interface ModalContentProps extends OUIAProps {
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
   ouiaSafe?: boolean;
-  /** Whether the Modal should open/close with animations. (BETA) */
-  animated?: boolean;
+  /** Flag indicating whether animations are enabled. */
+  hasAnimations?: boolean;
 }
 
 export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
@@ -74,10 +74,12 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   ouiaSafe = true,
   elementToFocus,
   focusTrapId,
-  animated,
+  hasAnimations: hasAnimationsProp,
   ...props
 }: ModalContentProps) => {
-  if (!isOpen && !animated) {
+  const hasAnimations = useHasAnimations(hasAnimationsProp);
+
+  if (!isOpen && !hasAnimations) {
     return null;
   }
 
@@ -95,7 +97,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     <ModalBox
       className={css(className)}
       isOpen={isOpen}
-      animated={animated}
+      hasAnimations={hasAnimations}
       variant={variant}
       position={position}
       positionOffset={positionOffset}
@@ -119,12 +121,12 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     </ModalBox>
   );
   let focusTrapActive = !disableFocusTrap;
-  if (animated) {
+  if (hasAnimations) {
     focusTrapActive = !disableFocusTrap && isOpen;
   }
 
   return (
-    <Backdrop className={css(backdropClassName)} id={backdropId} animated={animated} isVisible={isOpen}>
+    <Backdrop className={css(backdropClassName)} id={backdropId} hasAnimations={hasAnimations} isVisible={isOpen}>
       <FocusTrap
         active={focusTrapActive}
         focusTrapOptions={{

--- a/packages/react-core/src/components/Modal/examples/Modal.css
+++ b/packages/react-core/src/components/Modal/examples/Modal.css
@@ -1,0 +1,81 @@
+/**
+ * Modal.css
+ *
+ * To fix an issue with the PR preview deployment,
+ * this file contains the contents of the new modal-animations.css + backdrop-animations.css
+ */
+
+
+/* --- modal-animations.css ------ */
+
+.pf-v6-c-modal-animated {
+    --pf-v6-c-modal-animated--Transition:
+        opacity 240ms cubic-bezier(0.4, 0.14, 1, 1),
+        transform 240ms cubic-bezier(0.4, 0.14, 1, 1),
+        visibility 0ms linear 240ms;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translate3d(0, -24px, 0);
+    transform-origin: top center;
+    transition: var(--pf-v6-c-modal-animated--Transition);
+}
+
+.pf-v6-c-modal-animated-open {
+    --pf-v6-c-modal-animated--Transition:
+        transform 240ms cubic-bezier(0, 0, 0.2, 1),
+        visibility 0ms linear 0ms;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: unset;
+    transform: translate3d(0, 0, 0);
+}
+
+.pf-v6-c-modal-animated-closed {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translate3d(0, -24px, 0);
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+    .pf-v6-c-modal-animated,
+    .pf-v6-c-modal-animated-open,
+    .pf-v6-c-modal-animated-closed {
+        transition: none;
+    }
+}
+
+/* --- backdrop-animations.css --- */
+
+.pf-v6-c-backdrop-animated {
+    background-color: transparent;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+    background-color 240ms cubic-bezier(0.4, 0.14, 1, 1), /* Carbon equivalent: duration-moderate-02 + motion(exit, expressive) */
+    visibility 0ms linear 240ms; /* Carbon equivalent: duration-moderate-02 */
+}
+
+.pf-v6-c-backdrop-animated-visible {
+    background-color: var(--pf-v6-c-backdrop--BackgroundColor);
+    visibility: visible;
+    pointer-events: unset;
+    transition:
+    background-color 240ms cubic-bezier(0, 0, 0.2, 1),
+    visibility 0ms linear 0ms;
+}
+
+.pf-v6-c-backdrop-animated-hidden {
+    background-color: transparent;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+    .pf-v6-c-backdrop-animated,
+    .pf-v6-c-backdrop-animated-visible,
+    .pf-v6-c-backdrop-animated-hidden {
+        transition: none;
+    }
+}

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -7,10 +7,8 @@ ouia: true
 ---
 
 import { Fragment, useRef, useState } from 'react';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
-import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
+import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import RhUiAttentionBellFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-attention-bell-fill-icon';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
 
 ## Examples

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -9,6 +9,7 @@ ouia: true
 import { Fragment, useRef, useState } from 'react';
 import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
 import RhUiAttentionBellFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-attention-bell-fill-icon';
+import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
 
 ## Examples

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -156,11 +156,18 @@ To customize which element inside the modal receives focus when initially opened
 
 ```
 
-### Animated modal
+### Animated modal (hasAnimations)
 
-To allow modals to animate as they open and close, set the `animated` property accordingly.
-_Animated modals may have an impact on rendering performance_
+To allow modals to animate as they open and close, set the `hasAnimations` property on the modal.
 
 ```ts file="./ModalAnimated.tsx"
+
+```
+
+### Animated modal (AnimationsProvider)
+
+To enable animations globally, wrap your application with `AnimationsProvider`. All modals within the provider will animate without needing individual `hasAnimations` props.
+
+```ts file="./ModalAnimatedProvider.tsx"
 
 ```

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -11,6 +11,7 @@ import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warnin
 import RhUiAttentionBellFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-attention-bell-fill-icon';
 import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
+import './Modal.css';
 
 ## Examples
 

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -7,9 +7,10 @@ ouia: true
 ---
 
 import { Fragment, useRef, useState } from 'react';
-import RhUiWarningIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-warning-icon';
+import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';
+import RhMicronsCaretDownIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-down-icon';
 import RhUiAttentionBellFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-attention-bell-fill-icon';
-import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
 
 ## Examples
@@ -152,5 +153,14 @@ To enable form submission from a button in the modal's footer (outside of the `<
 To customize which element inside the modal receives focus when initially opened, use the `elementToFocus` property`.
 
 ```ts file="./ModalCustomFocus.tsx"
+
+```
+
+### Animated modal
+
+To allow modals to animate as they open and close, set the `animated` property accordingly.
+_Animated modals may have an impact on rendering performance_
+
+```ts file="./ModalAnimated.tsx"
 
 ```

--- a/packages/react-core/src/components/Modal/examples/ModalAnimated.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalAnimated.tsx
@@ -1,0 +1,43 @@
+import { Fragment, useState } from 'react';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, ModalVariant } from '@patternfly/react-core';
+
+export const ModalAnimated: React.FunctionComponent = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleModalToggle = (_event: KeyboardEvent | React.MouseEvent) => {
+    setIsModalOpen((prevIsModalOpen) => !prevIsModalOpen);
+  };
+
+  return (
+    <Fragment>
+      <Button variant="primary" onClick={handleModalToggle}>
+        Show animated modal
+      </Button>
+      <Modal
+        animated
+        variant={ModalVariant.large}
+        isOpen={isModalOpen}
+        aria-labelledby="modal-animated-label"
+        aria-describedby="modal-animated-description"
+        elementToFocus="#modal-custom-focus-confirm-button"
+      >
+        <ModalHeader title="Animated Modal Header" labelId="modal-animated-label" />
+        <ModalBody id="modal-animated-description">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </ModalBody>
+        <ModalFooter>
+          <Button id="modal-custom-focus-confirm-button" key="confirm" variant="primary" onClick={handleModalToggle}>
+            Confirm
+          </Button>
+          <Button key="cancel" variant="link" onClick={handleModalToggle}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Fragment>
+  );
+};

--- a/packages/react-core/src/components/Modal/examples/ModalAnimated.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalAnimated.tsx
@@ -14,12 +14,12 @@ export const ModalAnimated: React.FunctionComponent = () => {
         Show animated modal
       </Button>
       <Modal
-        animated
+        hasAnimations
         variant={ModalVariant.large}
         isOpen={isModalOpen}
         aria-labelledby="modal-animated-label"
         aria-describedby="modal-animated-description"
-        elementToFocus="#modal-custom-focus-confirm-button"
+        elementToFocus="#modal-animated-confirm-button"
       >
         <ModalHeader title="Animated Modal Header" labelId="modal-animated-label" />
         <ModalBody id="modal-animated-description">
@@ -30,7 +30,7 @@ export const ModalAnimated: React.FunctionComponent = () => {
           est laborum.
         </ModalBody>
         <ModalFooter>
-          <Button id="modal-custom-focus-confirm-button" key="confirm" variant="primary" onClick={handleModalToggle}>
+          <Button id="modal-animated-confirm-button" key="confirm" variant="primary" onClick={handleModalToggle}>
             Confirm
           </Button>
           <Button key="cancel" variant="link" onClick={handleModalToggle}>

--- a/packages/react-core/src/components/Modal/examples/ModalAnimated.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalAnimated.tsx
@@ -17,6 +17,7 @@ export const ModalAnimated: React.FunctionComponent = () => {
         hasAnimations
         variant={ModalVariant.large}
         isOpen={isModalOpen}
+        onClose={handleModalToggle}
         aria-labelledby="modal-animated-label"
         aria-describedby="modal-animated-description"
         elementToFocus="#modal-animated-confirm-button"

--- a/packages/react-core/src/components/Modal/examples/ModalAnimatedProvider.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalAnimatedProvider.tsx
@@ -1,0 +1,57 @@
+import { Fragment, useState } from 'react';
+import {
+  AnimationsProvider,
+  Button,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalVariant
+} from '@patternfly/react-core';
+
+export const ModalAnimatedProvider: React.FunctionComponent = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleModalToggle = (_event: KeyboardEvent | React.MouseEvent) => {
+    setIsModalOpen((prevIsModalOpen) => !prevIsModalOpen);
+  };
+
+  return (
+    <AnimationsProvider config={{ hasAnimations: true }}>
+      <Fragment>
+        <Button variant="primary" onClick={handleModalToggle}>
+          Show animated modal (via AnimationsProvider)
+        </Button>
+        <Modal
+          variant={ModalVariant.large}
+          isOpen={isModalOpen}
+          aria-labelledby="modal-animated-provider-label"
+          aria-describedby="modal-animated-provider-description"
+          elementToFocus="#modal-animated-provider-confirm-button"
+        >
+          <ModalHeader title="Animated Modal Header" labelId="modal-animated-provider-label" />
+          <ModalBody id="modal-animated-provider-description">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              id="modal-animated-provider-confirm-button"
+              key="confirm"
+              variant="primary"
+              onClick={handleModalToggle}
+            >
+              Confirm
+            </Button>
+            <Button key="cancel" variant="link" onClick={handleModalToggle}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </Fragment>
+    </AnimationsProvider>
+  );
+};

--- a/packages/react-core/src/components/Modal/examples/ModalAnimatedProvider.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalAnimatedProvider.tsx
@@ -25,6 +25,7 @@ export const ModalAnimatedProvider: React.FunctionComponent = () => {
         <Modal
           variant={ModalVariant.large}
           isOpen={isModalOpen}
+          onClose={handleModalToggle}
           aria-labelledby="modal-animated-provider-label"
           aria-describedby="modal-animated-provider-description"
           elementToFocus="#modal-animated-provider-confirm-button"

--- a/packages/react-styles/src/css/components/BackdropAnimations/backdrop-animations.css
+++ b/packages/react-styles/src/css/components/BackdropAnimations/backdrop-animations.css
@@ -1,0 +1,36 @@
+.pf-v6-c-backdrop-animated {
+    background-color: transparent;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+    background-color 240ms cubic-bezier(0.4, 0.14, 1, 1), /* Carbon equivalent: duration-moderate-02 + motion(exit, expressive) */
+    visibility 0ms linear 240ms; /* Carbon equivalent: duration-moderate-02 */
+}
+
+.pf-v6-c-backdrop-animated-visible {
+    background-color: var(--pf-v6-c-backdrop--BackgroundColor);
+    visibility: visible;
+    pointer-events: unset;
+    transition:
+    background-color 240ms cubic-bezier(0, 0, 0.2, 1),
+    visibility 0ms linear 0ms;
+}
+
+.pf-v6-c-backdrop-animated-hidden {
+    background-color: transparent;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+/* TODO [Gustavo]: My local setup has reduced animations at the OS level which kicks this media query on.
+     Chrome doesn't have an easy way to FORCE animations on in this case so commenting this out for now.
+     It should be enabled if PR is merged in. */
+/* *
+@media screen and (prefers-reduced-motion: reduce) {
+    .pf-v6-c-backdrop-animated,
+    .pf-v6-c-backdrop-animated-visible,
+    .pf-v6-c-backdrop-animated-hidden {
+        transition: none;
+    }
+}
+/* */

--- a/packages/react-styles/src/css/components/BackdropAnimations/backdrop-animations.css
+++ b/packages/react-styles/src/css/components/BackdropAnimations/backdrop-animations.css
@@ -22,10 +22,6 @@
     pointer-events: none;
 }
 
-/* TODO [Gustavo]: My local setup has reduced animations at the OS level which kicks this media query on.
-     Chrome doesn't have an easy way to FORCE animations on in this case so commenting this out for now.
-     It should be enabled if PR is merged in. */
-/* *
 @media screen and (prefers-reduced-motion: reduce) {
     .pf-v6-c-backdrop-animated,
     .pf-v6-c-backdrop-animated-visible,
@@ -33,4 +29,3 @@
         transition: none;
     }
 }
-/* */

--- a/packages/react-styles/src/css/components/ModalAnimations/modal-animations.css
+++ b/packages/react-styles/src/css/components/ModalAnimations/modal-animations.css
@@ -1,0 +1,42 @@
+.pf-v6-c-modal-animated {
+    --pf-v6-c-modal-animated--Transition:
+        opacity 240ms cubic-bezier(0.4, 0.14, 1, 1),
+        transform 240ms cubic-bezier(0.4, 0.14, 1, 1),
+        visibility 0ms linear 240ms;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translate3d(0, -24px, 0);
+    transform-origin: top center;
+    transition: var(--pf-v6-c-modal-animated--Transition);
+}
+
+.pf-v6-c-modal-animated-open {
+    --pf-v6-c-modal-animated--Transition:
+        transform 240ms cubic-bezier(0, 0, 0.2, 1),
+        visibility 0ms linear 0ms;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: unset;
+    transform: translate3d(0, 0, 0);
+}
+
+.pf-v6-c-modal-animated-closed {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translate3d(0, -24px, 0);
+}
+
+/* TODO [Gustavo]: My local setup has reduced animations at the OS level which kicks this media query on.
+     Chrome doesn't have an easy way to FORCE animations on in this case so commenting this out for now.
+     It should be enabled if PR is merged in. */
+/* *
+@media screen and (prefers-reduced-motion: reduce) {
+    .pf-v6-c-modal-animated,
+    .pf-v6-c-modal-animated-open,
+    .pf-v6-c-modal-animated-closed {
+        transition: none;
+    }
+}
+/* */

--- a/packages/react-styles/src/css/components/ModalAnimations/modal-animations.css
+++ b/packages/react-styles/src/css/components/ModalAnimations/modal-animations.css
@@ -28,10 +28,6 @@
     transform: translate3d(0, -24px, 0);
 }
 
-/* TODO [Gustavo]: My local setup has reduced animations at the OS level which kicks this media query on.
-     Chrome doesn't have an easy way to FORCE animations on in this case so commenting this out for now.
-     It should be enabled if PR is merged in. */
-/* *
 @media screen and (prefers-reduced-motion: reduce) {
     .pf-v6-c-modal-animated,
     .pf-v6-c-modal-animated-open,
@@ -39,4 +35,3 @@
         transition: none;
     }
 }
-/* */

--- a/packages/react-tokens/scripts/generateTokens.mjs
+++ b/packages/react-tokens/scripts/generateTokens.mjs
@@ -33,11 +33,11 @@ const getDeclarations = (cssAst) =>
     .reduce((acc, val) => acc.concat(val), []); // flatten
 
 const formatFilePathToName = (filePath) => {
-  // const filePathArr = filePath.split('/');
+  const normalizedPath = filePath.replace(/\\/g, '/');
   let prefix = '';
-  if (filePath.includes('components/')) {
+  if (normalizedPath.includes('components/')) {
     prefix = 'c_';
-  } else if (filePath.includes('layouts/')) {
+  } else if (normalizedPath.includes('layouts/')) {
     prefix = 'l_';
   }
   return `${prefix}${basename(filePath, '.css').replace(/-+/g, '_')}`;

--- a/scripts/build-single-packages.mjs
+++ b/scripts/build-single-packages.mjs
@@ -43,6 +43,7 @@ const components = {
 };
 
 async function createPackage(component) {
+  component = component.replaceAll('\\', '/');
   const cmds = [];
   let destFile = component.replace(/[^/]+\.js$/g, 'package.json').replace('/dist/esm/', '/dist/dynamic/');
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
- Closes patternfly/patternfly-react#12551

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: 
- https://github.com/patternfly/react-component-groups/issues/966

## Summary

This PR adds opt-in animations to the `<Modal>`, and `<Backdrop>` components.

## Evidence

**Video:** Modal animations in doc page as new example

https://github.com/user-attachments/assets/6c2b5ee7-d2f1-42c6-8225-753728d531d0

**Video:** Slowed down animations to 25% speed

https://github.com/user-attachments/assets/270a4a79-0114-4b89-986b-0e8229725604

## Detail: `ModalBox`'s `return null`

Notably; the ModalBox was previously returning null which made the animation less desirable since the entire modal content was not rendered.
``` JS
// Before
if (!isOpen) {
  return null
}
```
Now the ModalBox will skip this and only `return null` when animations are not set.
``` JS
// After
if (!isOpen && !hasAnimations) {
  return null;
}
```

## Detail: `modal-animations.css` & `backdrop-animations.css`

Just to get this change easily-tested and off the ground I've added the styles directly into the react-styles package.
Ideally these styles would live upstream in [patternfly/modal-box.scss](https://github.com/patternfly/patternfly/blob/main/src/patternfly/components/ModalBox/modal-box.scss) and other relevant areas.

## Detail: Build tweaks to `generateTokens.mjs` & `build-single-packages.mjs`

I'm running locally on Windows where path separators are `\` instead of the `/`.
While running locally, some build scripts fail because of this and tweaks were made in order to get a successful build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated modal transitions with coordinated backdrop animation states.
  * Introduced animation-control props for Modal/ModalBox/ModalContent/Backdrop to align open/closed and visibility behavior.
  * Added `prefers-reduced-motion` handling to disable animations for reduced-motion users.
* **Documentation**
  * Added example components and an updated modal example page covering animated modals and provider-based animation enabling.
* **Bug Fixes**
  * Improved cross-platform path normalization during token and single-package build generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->