### PR TITLE
chore(docs): Custom color example should use fewer sections

### DIFF
--- a/packages/react-charts/src/victory/components/ChartPie/examples/ChartPieCustomColorScale.tsx
+++ b/packages/react-charts/src/victory/components/ChartPie/examples/ChartPieCustomColorScale.tsx
@@ -11,12 +11,12 @@ interface Data {
 
 export const ChartPieCustomColorScale: React.FunctionComponent = () => {
   const data: Data[] = [
-    { x: 'Sky', y: 38 },
     { x: 'Shady side of pyramid', y: 7 },
     { x: 'Sunny side of pyramid', y: 17 },
-    { x: 'Sky', y: 38 }
+    { x: 'Sky', y: 76 }
   ];
   const legendData: Data[] = [{ name: 'Sky' }, { name: 'Shady side of pyramid' }, { name: 'Sunny side of pyramid' }];
+  const pyramidStartAngle = 0.38 * 360;
 
   return (
     <div style={{ height: '230px', width: '450px' }}>
@@ -24,7 +24,6 @@ export const ChartPieCustomColorScale: React.FunctionComponent = () => {
         ariaDesc="Average number of pets"
         ariaTitle="Pie chart example"
         colorScale={[
-          chart_theme_blue_ColorScale_100.var,
           chart_theme_orange_ColorScale_300.var,
           chart_theme_yellow_ColorScale_100.var,
           chart_theme_blue_ColorScale_100.var
@@ -37,6 +36,8 @@ export const ChartPieCustomColorScale: React.FunctionComponent = () => {
         legendOrientation="vertical"
         legendPosition="right"
         name="chart2"
+        endAngle={pyramidStartAngle + 360}
+        startAngle={pyramidStartAngle}
         padding={{
           bottom: 20,
           left: 20,


### PR DESCRIPTION
Two blue sections were being used. This caused a problem in high contrast mode since the sections are highlighted. This commit should adjust us down to one section, but allow us to keep the cute pyramid-in-sky effect.

Example: https://pf-react-pr-12559.surge.sh/components/charts/pie-chart#custom-color-scale

Fixes https://github.com/patternfly/patternfly-react/issues/12423

Assisted-by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the custom-color pie chart example to display the correct slice values and labels.
  * Corrected pie chart angle calculations for consistent full-circle rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->