### PR TITLE
chore(Popover): Include OUIAProps for Popover

### DIFF
--- a/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`With popover opened 1`] = `
             <input
               aria-invalid="false"
               aria-label="Date picker"
-              data-ouia-component-id="OUIA-Generated-TextInputBase-:rq:"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-:r11:"
               data-ouia-component-type="PF6/TextInput"
               data-ouia-safe="true"
               placeholder="YYYY-MM-DD"
@@ -37,7 +37,7 @@ exports[`With popover opened 1`] = `
             aria-haspopup="dialog"
             aria-label="Toggle date picker"
             class="pf-v6-c-button pf-m-control"
-            data-ouia-component-id="OUIA-Generated-Button-control-:rr:"
+            data-ouia-component-id="OUIA-Generated-Button-control-:r12:"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -64,10 +64,13 @@ exports[`With popover opened 1`] = `
       </div>
     </div>
     <div
-      aria-describedby="popover-pf-:ro:-body"
+      aria-describedby="popover-pf-:ru:-body"
       aria-label=""
       aria-modal="true"
       class="pf-v6-c-popover pf-m-no-padding pf-m-width-auto pf-m-bottom"
+      data-ouia-component-id="OUIA-Generated-Popover-:rv:"
+      data-ouia-component-type="PF6/Popover"
+      data-ouia-safe="true"
       data-popper-escaped="true"
       data-popper-placement="bottom"
       data-popper-reference-hidden="true"
@@ -82,7 +85,7 @@ exports[`With popover opened 1`] = `
       >
         <div
           class="pf-v6-c-popover__body"
-          id="popover-pf-:ro:-body"
+          id="popover-pf-:ru:-body"
         >
           <div
             class="pf-v6-c-calendar-month"
@@ -96,7 +99,7 @@ exports[`With popover opened 1`] = `
                 <button
                   aria-label="Previous month"
                   class="pf-v6-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-:rt:"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-:r14:"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   type="button"
@@ -131,7 +134,7 @@ exports[`With popover opened 1`] = `
                   >
                     <span
                       hidden=""
-                      id="hidden-month-span:rs:"
+                      id="hidden-month-span:r13:"
                     >
                       Month
                     </span>
@@ -139,7 +142,7 @@ exports[`With popover opened 1`] = `
                       aria-expanded="false"
                       aria-haspopup="menu"
                       class="pf-v6-c-menu-toggle"
-                      data-ouia-component-id="OUIA-Generated-MenuToggle-:r10:"
+                      data-ouia-component-id="OUIA-Generated-MenuToggle-:r17:"
                       data-ouia-component-type="PF6/MenuToggle"
                       data-ouia-safe="true"
                       style="width: 140px;"
@@ -186,7 +189,7 @@ exports[`With popover opened 1`] = `
                       <input
                         aria-invalid="false"
                         aria-label="Select year"
-                        data-ouia-component-id="OUIA-Generated-TextInputBase-:r12:"
+                        data-ouia-component-id="OUIA-Generated-TextInputBase-:r19:"
                         data-ouia-component-type="PF6/TextInput"
                         data-ouia-safe="true"
                         type="number"
@@ -202,7 +205,7 @@ exports[`With popover opened 1`] = `
                 <button
                   aria-label="Next month"
                   class="pf-v6-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-:r13:"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-:r1a:"
                   data-ouia-component-type="PF6/Button"
                   data-ouia-safe="true"
                   type="button"
@@ -813,7 +816,7 @@ exports[`disabled date picker 1`] = `
             <input
               aria-invalid="false"
               aria-label="disabled date picker"
-              data-ouia-component-id="OUIA-Generated-TextInputBase-:r2:"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-:r3:"
               data-ouia-component-type="PF6/TextInput"
               data-ouia-safe="true"
               disabled=""
@@ -830,7 +833,7 @@ exports[`disabled date picker 1`] = `
             aria-haspopup="dialog"
             aria-label="Toggle date picker"
             class="pf-v6-c-button pf-m-control"
-            data-ouia-component-id="OUIA-Generated-Button-control-:r3:"
+            data-ouia-component-id="OUIA-Generated-Button-control-:r4:"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             disabled=""

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -11,9 +11,8 @@ import { PopoverCloseButton } from './PopoverCloseButton';
 import { PopoverArrow } from './PopoverArrow';
 import popoverMaxWidth from '@patternfly/react-tokens/dist/esm/c_popover_MaxWidth';
 import popoverMinWidth from '@patternfly/react-tokens/dist/esm/c_popover_MinWidth';
-import { FocusTrap } from '../../helpers';
+import { FocusTrap, useSSRSafeId, useOUIAProps, OUIAProps } from '../../helpers';
 import { Popper } from '../../helpers/Popper/Popper';
-import { useSSRSafeId } from '../../helpers';
 
 export enum PopoverPosition {
   auto = 'auto',
@@ -35,7 +34,7 @@ export enum PopoverPosition {
  * that has a property specifically for passing in popover properties.
  */
 
-export interface PopoverProps {
+export interface PopoverProps extends OUIAProps {
   /** Text announced by screen reader when alert severity variant is set to indicate
    * severity level.
    */
@@ -213,6 +212,10 @@ export interface PopoverProps {
   withFocusTrap?: boolean;
   /** The z-index of the popover. */
   zIndex?: number;
+  /** Value to overwrite the randomly generated data-ouia-component-id.*/
+  ouiaId?: number | string;
+  /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
+  ouiaSafe?: boolean;
 }
 
 const alertStyle = {
@@ -274,12 +277,15 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   hasNoPadding = false,
   hasAutoWidth = false,
   elementToFocus,
+  ouiaId,
+  ouiaSafe = true,
   ...rest
 }: PopoverProps) => {
   // could make this a prop in the future (true | false | 'toggle')
   // const hideOnClick = true;
   const generatedId = useSSRSafeId();
   const uniqueId = id || generatedId;
+  const ouiaProps = useOUIAProps(Popover.displayName, ouiaId, ouiaSafe);
   const triggerManually = isVisible !== null;
   const [visible, setVisible] = useState(false);
   const [focusTrapActive, setFocusTrapActive] = useState(Boolean(propWithFocusTrap));
@@ -475,6 +481,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
         maxWidth: hasCustomMaxWidth ? maxWidth : null
       }}
       {...rest}
+      {...ouiaProps}
     >
       <PopoverArrow />
       <PopoverContent>

--- a/packages/react-core/src/components/Popover/__tests__/Popover.test.tsx
+++ b/packages/react-core/src/components/Popover/__tests__/Popover.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Popover, PopoverPosition } from '../Popover';
 
 test('popover renders close-button, header and body', () => {
@@ -9,6 +9,7 @@ test('popover renders close-button, header and body', () => {
       position="top"
       isVisible
       hideOnOutsideClick
+      ouiaId="ouia-id"
       headerContent={<div>Popover Header</div>}
       bodyContent={
         <div>
@@ -113,4 +114,46 @@ test('popover renders in strict mode', () => {
   );
   expect(consoleError).not.toHaveBeenCalled();
   expect(asFragment()).toMatchSnapshot();
+});
+
+test('Renders with custom ouiaId', () => {
+  render(
+    <Popover isVisible ouiaId="test-id" headerContent={<div>Popover Header</div>} bodyContent={<div>Popover body</div>}>
+      <div>Toggle Popover</div>
+    </Popover>
+  );
+  expect(screen.getByRole('dialog')).toHaveAttribute('data-ouia-component-id', 'test-id');
+});
+
+test('Renders with expected ouia component type', () => {
+  render(
+    <Popover isVisible ouiaId="test-id" headerContent={<div>Popover Header</div>} bodyContent={<div>Popover body</div>}>
+      <div>Toggle Popover</div>
+    </Popover>
+  );
+  expect(screen.getByRole('dialog')).toHaveAttribute('data-ouia-component-type', 'PF6/Popover');
+});
+
+test('Renders with ouiaSafe defaulting to true', () => {
+  render(
+    <Popover isVisible ouiaId="test-id" headerContent={<div>Popover Header</div>} bodyContent={<div>Popover body</div>}>
+      <div>Toggle Popover</div>
+    </Popover>
+  );
+  expect(screen.getByRole('dialog')).toHaveAttribute('data-ouia-safe', 'true');
+});
+
+test('Renders with ouiaSafe=false when specified', () => {
+  render(
+    <Popover
+      isVisible
+      ouiaId="test-id"
+      ouiaSafe={false}
+      headerContent={<div>Popover Header</div>}
+      bodyContent={<div>Popover body</div>}
+    >
+      <div>Toggle Popover</div>
+    </Popover>
+  );
+  expect(screen.getByRole('dialog')).toHaveAttribute('data-ouia-safe', 'false');
 });

--- a/packages/react-core/src/helpers/OUIA/OUIA.md
+++ b/packages/react-core/src/helpers/OUIA/OUIA.md
@@ -71,6 +71,7 @@ component.
 * [NavExpandable](/components/navigation)
 * [NavItem](/components/navigation)
 * [Pagination](/components/pagination)
+* [Popover](/components/popover)
 * [Progress](/components/progress)
 * [Radio](/components/forms/radio)
 * [Select](/components/menus/select)


### PR DESCRIPTION
Add OUIA attribute support to Popover for better test automation. OUIA attributes are applied to the FocusTrap dialog root.

**What**: 
Closes #12571

**Snapshot tests commit**
https://github.com/patternfly/patternfly-react/issues/12573
https://github.com/patternfly/patternfly-react/pull/12574/changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OUIA support to the Popover component for improved automation and testing.
  - Popovers now expose component type, custom component IDs, and safety attributes.
  - Added configuration options for setting the OUIA ID and controlling the safety attribute, which defaults to enabled.

- **Documentation**
  - Updated OUIA documentation to list Popover as a supported component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->