### PR TITLE
chore(ClipboardCopy): Document ClipboardCopy as OUIA-compliant

### DIFF
--- a/packages/react-core/src/helpers/OUIA/OUIA.md
+++ b/packages/react-core/src/helpers/OUIA/OUIA.md
@@ -54,6 +54,7 @@ component.
 * [Card](/components/card)
 * [Checkbox](/components/forms/checkbox)
 * [Chip](/components/chip)
+* [ClipboardCopy](/components/clipboard-copy)
 * [Content](/components/content)
 * [Dropdown](/components/menus/dropdown)
 * [DropdownItem](/components/menus/dropdown)


### PR DESCRIPTION
ClipboardCopy already emits OUIA attributes via getOUIAProps; add it to the documented list of OUIA-compliant components.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OUIA compliance documentation to include the `ClipboardCopy` component among supported PatternFly 5 components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->