### PR TITLE
chore(deps): Bump docs framework

### DIFF
--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -37,7 +37,7 @@
     "victory": "^37.3.6"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "^6.36.8",
+    "@patternfly/documentation-framework": "^6.40.0",
     "@patternfly/patternfly-a11y": "5.2.1"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,9 +4963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/documentation-framework@npm:^6.36.8":
-  version: 6.36.8
-  resolution: "@patternfly/documentation-framework@npm:6.36.8"
+"@patternfly/documentation-framework@npm:^6.40.0":
+  version: 6.49.2
+  resolution: "@patternfly/documentation-framework@npm:6.49.2"
   dependencies:
     "@babel/core": "npm:^7.29.0"
     "@babel/preset-env": "npm:7.29.0"
@@ -5026,16 +5026,16 @@ __metadata:
     webpack-dev-server: "npm:5.2.3"
     webpack-merge: "npm:5.10.0"
   peerDependencies:
-    "@patternfly/patternfly": ^6.5.0-prerelease.46
-    "@patternfly/react-code-editor": ^6.5.0-prerelease.39
-    "@patternfly/react-core": ^6.5.0-prerelease.36
-    "@patternfly/react-icons": ^6.5.0-prerelease.15
-    "@patternfly/react-table": ^6.5.0-prerelease.37
+    "@patternfly/patternfly": ^6.6.0
+    "@patternfly/react-code-editor": ^6.6.0
+    "@patternfly/react-core": ^6.6.0
+    "@patternfly/react-icons": ^6.6.0
+    "@patternfly/react-table": ^6.6.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
   bin:
     pf-docs-framework: scripts/cli/cli.js
-  checksum: 10c0/bf29256be06e32e130d6146a8d5cc9744e0b88463b69f9c2ef6bae98f0ffee15901760fb69c3737d7fdcf2d612511d034c7661568c92187ead143fe772f8d561
+  checksum: 10c0/1d80d9d6078237d17b71deeb4ffa4b7ad6ed43c0d424c6044de4420d5ef8267eb913e281fc97ffa9fe6d6e70b0462557c22fdf50ecca9df555163eb48ab40ff5
   languageName: node
   linkType: hard
 
@@ -5191,7 +5191,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
-    "@patternfly/documentation-framework": "npm:^6.36.8"
+    "@patternfly/documentation-framework": "npm:^6.40.0"
     "@patternfly/patternfly": "npm:6.6.0-prerelease.20"
     "@patternfly/patternfly-a11y": "npm:5.2.1"
     "@patternfly/react-charts": "workspace:^"


### PR DESCRIPTION
Andrew reports that the wrong Felt class is being added to the html tag. I bumped the docs framework to one that has the correct class, https://github.com/patternfly/patternfly-org/pull/5003/changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation framework tooling to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->