### PR TITLE
docs(OverflowMenu): expose OverflowMenuContext in docs

### DIFF
--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -9,7 +9,8 @@ propComponents:
     'OverflowMenuControl',
     'OverflowMenuDropdownItem',
     'OverflowMenuGroup',
-    'OverflowMenuItem'
+    'OverflowMenuItem',
+    'OverflowMenuContext'
   ]
 ---
 

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -9,8 +9,7 @@ propComponents:
     'OverflowMenuControl',
     'OverflowMenuDropdownItem',
     'OverflowMenuGroup',
-    'OverflowMenuItem',
-    'OverflowMenuContext'
+    'OverflowMenuItem'
   ]
 ---
 
@@ -19,6 +18,8 @@ import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-ico
 import AlignCenterIcon from '@patternfly/react-icons/dist/esm/icons/align-center-icon';
 import AlignRightIcon from '@patternfly/react-icons/dist/esm/icons/align-right-icon';
 import RhUiEllipsisVerticalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-vertical-fill-icon';
+
+`OverflowMenuContext` is also available to import and use to further customize and refine behaviors that should respect responsive breakpoints. This context provides the `isBelowBreakpoint` boolean that will update when the specified breakpoint is reached.
 
 ## Examples
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12421


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Overflow Menu example documentation with additional guidance on using the Overflow Menu context to customize responsive, breakpoint-aware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->