### PR TITLE
feat(Page): add ref prop for main element

### DIFF
--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -97,6 +97,8 @@ export interface PageProps extends React.HTMLProps<HTMLDivElement> {
   horizontalSubnav?: React.ReactNode;
   /** Accessible label, can be used to name main section */
   mainAriaLabel?: string;
+  /** Reference for the main section of the page */
+  mainRef?: React.RefObject<HTMLDivElement>;
   /** Flag indicating if the horizontal sub navigation should be in a group */
   isHorizontalSubnavGrouped?: boolean;
   /** Flag indicating if the breadcrumb should be in a group */
@@ -132,9 +134,10 @@ class Page extends Component<PageProps, PageState> {
     onNotificationDrawerExpand: () => null,
     mainComponent: 'main',
     getBreakpoint,
-    getVerticalBreakpoint
+    getVerticalBreakpoint,
+    mainRef: undefined
   };
-  mainRef = createRef<HTMLDivElement>();
+  mainRef = this.props?.mainRef ? this.props.mainRef : createRef<HTMLDivElement>();
   pageRef = createRef<HTMLDivElement>();
   observer: any = () => {};
 

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -275,6 +275,8 @@ class Page extends Component<PageProps, PageState> {
       groupProps,
       breadcrumbProps,
       isContentFilled,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      mainRef,
       ...rest
     } = this.props;
     const { mobileView, mobileIsSidebarOpen, desktopIsSidebarOpen, width, height } = this.state;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12428

Adds `mainRef` property to allow a user to pass their own ref to Page's main element.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing an optional custom reference to a page’s main content container.
  * When a reference is supplied, the page will use it; otherwise it will continue to handle the main container reference automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->