### PR TITLE
chore(docs): Replace ActionGroup with ActionList

### DIFF
--- a/packages/react-core/src/components/Form/ActionGroup.tsx
+++ b/packages/react-core/src/components/Form/ActionGroup.tsx
@@ -1,6 +1,7 @@
 import styles from '@patternfly/react-styles/css/components/Form/form';
 import { css } from '@patternfly/react-styles';
 
+/** @deprecated Use ActionList, ActionListGroup, and ActionListItem instead. */
 export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Anything that can be rendered as ActionGroup content. */
   children?: React.ReactNode;
@@ -8,6 +9,7 @@ export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
+/** @deprecated Use ActionList, ActionListGroup, and ActionListItem instead. */
 export const ActionGroup: React.FunctionComponent<ActionGroupProps> = ({
   children = null,
   className = '',

--- a/packages/react-core/src/components/Form/ActionGroup.tsx
+++ b/packages/react-core/src/components/Form/ActionGroup.tsx
@@ -1,7 +1,7 @@
 import styles from '@patternfly/react-styles/css/components/Form/form';
 import { css } from '@patternfly/react-styles';
 
-/** @deprecated Use ActionList, ActionListGroup, and ActionListItem instead. */
+/** @deprecated Use ActionList, ActionListGroup, and ActionListItem in a FormGroup instead. */
 export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Anything that can be rendered as ActionGroup content. */
   children?: React.ReactNode;
@@ -9,7 +9,7 @@ export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
-/** @deprecated Use ActionList, ActionListGroup, and ActionListItem instead. */
+/** @deprecated Use ActionList, ActionListGroup, and ActionListItem in a FormGroup instead. */
 export const ActionGroup: React.FunctionComponent<ActionGroupProps> = ({
   children = null,
   className = '',

--- a/packages/react-core/src/components/Form/ActionGroup.tsx
+++ b/packages/react-core/src/components/Form/ActionGroup.tsx
@@ -1,7 +1,7 @@
 import styles from '@patternfly/react-styles/css/components/Form/form';
 import { css } from '@patternfly/react-styles';
 
-/** @deprecated Use ActionList, ActionListGroup, and ActionListItem in a FormGroup instead. */
+/** ActionGroup has been deprecated, please use ActionList, ActionListGroup, and ActionListItem in a FormGroup instead. */
 export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Anything that can be rendered as ActionGroup content. */
   children?: React.ReactNode;
@@ -9,7 +9,7 @@ export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
-/** @deprecated Use ActionList, ActionListGroup, and ActionListItem in a FormGroup instead. */
+/** ActionGroup has been deprecated, please use ActionList, ActionListGroup, and ActionListItem in a FormGroup instead. */
 export const ActionGroup: React.FunctionComponent<ActionGroupProps> = ({
   children = null,
   className = '',

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -21,6 +21,8 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   isInline?: boolean;
   /** Sets the FormGroupControl to be stacked */
   isStack?: boolean;
+  /** Sets the FormGroup action modifier. Used to contain form action buttons. */
+  isAction?: boolean;
   /** Removes top spacer from label. */
   hasNoPaddingTop?: boolean;
   /** ID of an individual field or a group of multiple fields. Required when a role of "group" or "radiogroup" is passed in.
@@ -47,6 +49,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   isInline = false,
   hasNoPaddingTop = false,
   isStack = false,
+  isAction = false,
   fieldId,
   role,
   ouiaId,
@@ -75,7 +78,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
 
   return (
     <div
-      className={css(styles.formGroup, className)}
+      className={css(styles.formGroup, isAction && styles.modifiers.action, className)}
       {...(role && { role })}
       {...(isGroupOrRadioGroup && { 'aria-labelledby': `${fieldId || randomId}-legend` })}
       {...props}

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -22,7 +22,7 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   /** Sets the FormGroupControl to be stacked */
   isStack?: boolean;
   /** Sets the FormGroup action modifier. Used to contain form action buttons. */
-  isAction?: boolean;
+  isActionGroup?: boolean;
   /** Removes top spacer from label. */
   hasNoPaddingTop?: boolean;
   /** ID of an individual field or a group of multiple fields. Required when a role of "group" or "radiogroup" is passed in.
@@ -49,7 +49,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   isInline = false,
   hasNoPaddingTop = false,
   isStack = false,
-  isAction = false,
+  isActionGroup = false,
   fieldId,
   role,
   ouiaId,
@@ -78,7 +78,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
 
   return (
     <div
-      className={css(styles.formGroup, isAction && styles.modifiers.action, className)}
+      className={css(styles.formGroup, isActionGroup && styles.modifiers.action, className)}
       {...(role && { role })}
       {...(isGroupOrRadioGroup && { 'aria-labelledby': `${fieldId || randomId}-legend` })}
       {...props}

--- a/packages/react-core/src/components/Form/__tests__/FormGroup.test.tsx
+++ b/packages/react-core/src/components/Form/__tests__/FormGroup.test.tsx
@@ -34,6 +34,15 @@ describe('FormGroup', () => {
     expect(screen.getByTestId('form-group-test-id').firstElementChild).toHaveClass('pf-m-no-padding-top');
   });
 
+  test('should render action form group variant', () => {
+    render(
+      <FormGroup isAction data-testid="form-group-test-id">
+        <button type="submit">Submit</button>
+      </FormGroup>
+    );
+    expect(screen.getByTestId('form-group-test-id')).toHaveClass('pf-m-action');
+  });
+
   test('should render form group variant with required label', () => {
     const { asFragment } = render(
       <FormGroup label="label" isRequired fieldId="label-id">

--- a/packages/react-core/src/components/Form/__tests__/FormGroup.test.tsx
+++ b/packages/react-core/src/components/Form/__tests__/FormGroup.test.tsx
@@ -36,7 +36,7 @@ describe('FormGroup', () => {
 
   test('should render action form group variant', () => {
     render(
-      <FormGroup isAction data-testid="form-group-test-id">
+      <FormGroup isActionGroup data-testid="form-group-test-id">
         <button type="submit">Submit</button>
       </FormGroup>
     );

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`FormGroup should render correctly when label is not a string with Child
 <DocumentFragment>
   <div
     class="pf-v6-c-form__group"
-    data-ouia-component-id="OUIA-Generated-FormGroup-:rm:"
+    data-ouia-component-id="OUIA-Generated-FormGroup-:ro:"
     data-ouia-component-type="PF6/FormGroup"
     data-ouia-safe="true"
   >
@@ -78,7 +78,7 @@ exports[`FormGroup should render form group variant with node label 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-form__group"
-    data-ouia-component-id="OUIA-Generated-FormGroup-:r8:"
+    data-ouia-component-id="OUIA-Generated-FormGroup-:ra:"
     data-ouia-component-type="PF6/FormGroup"
     data-ouia-safe="true"
   >
@@ -114,7 +114,7 @@ exports[`FormGroup should render form group variant with required label 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-form__group"
-    data-ouia-component-id="OUIA-Generated-FormGroup-:r6:"
+    data-ouia-component-id="OUIA-Generated-FormGroup-:r8:"
     data-ouia-component-type="PF6/FormGroup"
     data-ouia-safe="true"
   >
@@ -154,7 +154,7 @@ exports[`FormGroup should render form group variant without label 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-form__group"
-    data-ouia-component-id="OUIA-Generated-FormGroup-:rk:"
+    data-ouia-component-id="OUIA-Generated-FormGroup-:rm:"
     data-ouia-component-type="PF6/FormGroup"
     data-ouia-safe="true"
   >
@@ -173,7 +173,7 @@ exports[`FormGroup should render form group with additional label info 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-form__group"
-    data-ouia-component-id="OUIA-Generated-FormGroup-:ra:"
+    data-ouia-component-id="OUIA-Generated-FormGroup-:rc:"
     data-ouia-component-type="PF6/FormGroup"
     data-ouia-safe="true"
   >
@@ -218,14 +218,14 @@ exports[`FormGroup should render horizontal form group variant 1`] = `
 <DocumentFragment>
   <form
     class="pf-v6-c-form pf-m-horizontal"
-    data-ouia-component-id="OUIA-Generated-Form-:re:"
+    data-ouia-component-id="OUIA-Generated-Form-:rg:"
     data-ouia-component-type="PF6/Form"
     data-ouia-safe="true"
     novalidate=""
   >
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:rf:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:rh:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -260,14 +260,14 @@ exports[`FormGroup should render stacked horizontal form group variant 1`] = `
 <DocumentFragment>
   <form
     class="pf-v6-c-form pf-m-horizontal"
-    data-ouia-component-id="OUIA-Generated-Form-:rh:"
+    data-ouia-component-id="OUIA-Generated-Form-:rj:"
     data-ouia-component-type="PF6/Form"
     data-ouia-safe="true"
     novalidate=""
   >
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:ri:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:rk:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -6,6 +6,9 @@ cssPrefix: pf-v6-c-form
 propComponents:
   [
     'ActionGroup',
+    'ActionList',
+    'ActionListGroup',
+    'ActionListItem',
     'Form',
     'FormGroup',
     'FormGroupLabelHelp',

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -5,7 +5,9 @@ import {
   TextInput,
   Checkbox,
   Popover,
-  ActionGroup,
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
   Button,
   Radio,
   HelperText,
@@ -123,10 +125,16 @@ export const FormBasic: React.FunctionComponent = () => {
       <FormGroup fieldId="checkbox01">
         <Checkbox label="I'd like updates via email." id="checkbox01" name="checkbox01" aria-label="Update via email" />
       </FormGroup>
-      <ActionGroup>
-        <Button variant="primary">Submit</Button>
-        <Button variant="link">Cancel</Button>
-      </ActionGroup>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant="primary">Submit</Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button variant="link">Cancel</Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
     </Form>
   );
 };

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -125,16 +125,18 @@ export const FormBasic: React.FunctionComponent = () => {
       <FormGroup fieldId="checkbox01">
         <Checkbox label="I'd like updates via email." id="checkbox01" name="checkbox01" aria-label="Update via email" />
       </FormGroup>
-      <ActionList>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button variant="primary">Submit</Button>
-          </ActionListItem>
-          <ActionListItem>
-            <Button variant="link">Cancel</Button>
-          </ActionListItem>
-        </ActionListGroup>
-      </ActionList>
+      <FormGroup isAction>
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button variant="primary">Submit</Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button variant="link">Cancel</Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </FormGroup>
     </Form>
   );
 };

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -125,7 +125,7 @@ export const FormBasic: React.FunctionComponent = () => {
       <FormGroup fieldId="checkbox01">
         <Checkbox label="I'd like updates via email." id="checkbox01" name="checkbox01" aria-label="Update via email" />
       </FormGroup>
-      <FormGroup isAction>
+      <FormGroup isActionGroup>
         <ActionList>
           <ActionListGroup>
             <ActionListItem>

--- a/packages/react-core/src/components/Form/examples/FormHorizontal.tsx
+++ b/packages/react-core/src/components/Form/examples/FormHorizontal.tsx
@@ -114,16 +114,18 @@ export const FormHorizontal: React.FunctionComponent = () => {
         <Radio name="horizontal-inline-radio" label="Central" id="horizontal-inline-radio-02" />
         <Radio name="horizontal-inline-radio" label="Pacific" id="horizontal-inline-radio-03" />
       </FormGroup>
-      <ActionList>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button variant="primary">Submit</Button>
-          </ActionListItem>
-          <ActionListItem>
-            <Button variant="link">Cancel</Button>
-          </ActionListItem>
-        </ActionListGroup>
-      </ActionList>
+      <FormGroup isAction>
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button variant="primary">Submit</Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button variant="link">Cancel</Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </FormGroup>
     </Form>
   );
 };

--- a/packages/react-core/src/components/Form/examples/FormHorizontal.tsx
+++ b/packages/react-core/src/components/Form/examples/FormHorizontal.tsx
@@ -7,7 +7,9 @@ import {
   FormSelect,
   FormSelectOption,
   Checkbox,
-  ActionGroup,
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
   Button,
   Radio,
   HelperText,
@@ -112,10 +114,16 @@ export const FormHorizontal: React.FunctionComponent = () => {
         <Radio name="horizontal-inline-radio" label="Central" id="horizontal-inline-radio-02" />
         <Radio name="horizontal-inline-radio" label="Pacific" id="horizontal-inline-radio-03" />
       </FormGroup>
-      <ActionGroup>
-        <Button variant="primary">Submit</Button>
-        <Button variant="link">Cancel</Button>
-      </ActionGroup>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant="primary">Submit</Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button variant="link">Cancel</Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
     </Form>
   );
 };

--- a/packages/react-core/src/components/Form/examples/FormHorizontal.tsx
+++ b/packages/react-core/src/components/Form/examples/FormHorizontal.tsx
@@ -114,7 +114,7 @@ export const FormHorizontal: React.FunctionComponent = () => {
         <Radio name="horizontal-inline-radio" label="Central" id="horizontal-inline-radio-02" />
         <Radio name="horizontal-inline-radio" label="Pacific" id="horizontal-inline-radio-03" />
       </FormGroup>
-      <FormGroup isAction>
+      <FormGroup isActionGroup>
         <ActionList>
           <ActionListGroup>
             <ActionListItem>

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -5,7 +5,9 @@ import {
   TextInput,
   Checkbox,
   Popover,
-  ActionGroup,
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
   Button,
   Radio,
   HelperText,
@@ -123,10 +125,16 @@ export const FormLimitWidth: React.FunctionComponent = () => {
       <FormGroup fieldId="checkbox02">
         <Checkbox label="I'd like updates via email." id="checkbox02" name="checkbox02" aria-label="Update via email" />
       </FormGroup>
-      <ActionGroup>
-        <Button variant="primary">Submit</Button>
-        <Button variant="link">Cancel</Button>
-      </ActionGroup>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant="primary">Submit</Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button variant="link">Cancel</Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
     </Form>
   );
 };

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -125,16 +125,18 @@ export const FormLimitWidth: React.FunctionComponent = () => {
       <FormGroup fieldId="checkbox02">
         <Checkbox label="I'd like updates via email." id="checkbox02" name="checkbox02" aria-label="Update via email" />
       </FormGroup>
-      <ActionList>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button variant="primary">Submit</Button>
-          </ActionListItem>
-          <ActionListItem>
-            <Button variant="link">Cancel</Button>
-          </ActionListItem>
-        </ActionListGroup>
-      </ActionList>
+      <FormGroup isAction>
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button variant="primary">Submit</Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button variant="link">Cancel</Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </FormGroup>
     </Form>
   );
 };

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -125,7 +125,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
       <FormGroup fieldId="checkbox02">
         <Checkbox label="I'd like updates via email." id="checkbox02" name="checkbox02" aria-label="Update via email" />
       </FormGroup>
-      <FormGroup isAction>
+      <FormGroup isActionGroup>
         <ActionList>
           <ActionListGroup>
             <ActionListItem>

--- a/packages/react-core/src/components/Form/examples/FormState.tsx
+++ b/packages/react-core/src/components/Form/examples/FormState.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import {
-  ActionGroup,
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
   Button,
   ButtonType,
   ButtonVariant,
@@ -89,25 +91,34 @@ export const FormState = () => {
             </SelectList>
           </Select>
 
-          <ActionGroup>
-            <Button
-              type={ButtonType.submit}
-              onClick={(e) => {
-                e.preventDefault();
+          <ActionList>
+            <ActionListGroup>
+              <ActionListItem>
+                <Button
+                  type={ButtonType.submit}
+                  onClick={(e) => {
+                    e.preventDefault();
 
-                if (!values['input-id']) {
-                  setError('input-id', 'Input value is required.');
-                } else {
-                  alert(`Form submitted with: \n ${JSON.stringify(values)}`);
-                }
-              }}
-            >
-              Submit
-            </Button>
-            <Button variant={ButtonVariant.link} onClick={() => setFormStateExpanded((prevExpanded) => !prevExpanded)}>
-              {`${formStateExpanded ? 'Hide' : 'Show'} form state`}
-            </Button>
-          </ActionGroup>
+                    if (!values['input-id']) {
+                      setError('input-id', 'Input value is required.');
+                    } else {
+                      alert(`Form submitted with: \n ${JSON.stringify(values)}`);
+                    }
+                  }}
+                >
+                  Submit
+                </Button>
+              </ActionListItem>
+              <ActionListItem>
+                <Button
+                  variant={ButtonVariant.link}
+                  onClick={() => setFormStateExpanded((prevExpanded) => !prevExpanded)}
+                >
+                  {`${formStateExpanded ? 'Hide' : 'Show'} form state`}
+                </Button>
+              </ActionListItem>
+            </ActionListGroup>
+          </ActionList>
           {formStateExpanded && (
             <>
               <Divider />

--- a/packages/react-core/src/components/Form/examples/FormState.tsx
+++ b/packages/react-core/src/components/Form/examples/FormState.tsx
@@ -91,34 +91,36 @@ export const FormState = () => {
             </SelectList>
           </Select>
 
-          <ActionList>
-            <ActionListGroup>
-              <ActionListItem>
-                <Button
-                  type={ButtonType.submit}
-                  onClick={(e) => {
-                    e.preventDefault();
+          <FormGroup isAction>
+            <ActionList>
+              <ActionListGroup>
+                <ActionListItem>
+                  <Button
+                    type={ButtonType.submit}
+                    onClick={(e) => {
+                      e.preventDefault();
 
-                    if (!values['input-id']) {
-                      setError('input-id', 'Input value is required.');
-                    } else {
-                      alert(`Form submitted with: \n ${JSON.stringify(values)}`);
-                    }
-                  }}
-                >
-                  Submit
-                </Button>
-              </ActionListItem>
-              <ActionListItem>
-                <Button
-                  variant={ButtonVariant.link}
-                  onClick={() => setFormStateExpanded((prevExpanded) => !prevExpanded)}
-                >
-                  {`${formStateExpanded ? 'Hide' : 'Show'} form state`}
-                </Button>
-              </ActionListItem>
-            </ActionListGroup>
-          </ActionList>
+                      if (!values['input-id']) {
+                        setError('input-id', 'Input value is required.');
+                      } else {
+                        alert(`Form submitted with: \n ${JSON.stringify(values)}`);
+                      }
+                    }}
+                  >
+                    Submit
+                  </Button>
+                </ActionListItem>
+                <ActionListItem>
+                  <Button
+                    variant={ButtonVariant.link}
+                    onClick={() => setFormStateExpanded((prevExpanded) => !prevExpanded)}
+                  >
+                    {`${formStateExpanded ? 'Hide' : 'Show'} form state`}
+                  </Button>
+                </ActionListItem>
+              </ActionListGroup>
+            </ActionList>
+          </FormGroup>
           {formStateExpanded && (
             <>
               <Divider />

--- a/packages/react-core/src/components/Form/examples/FormState.tsx
+++ b/packages/react-core/src/components/Form/examples/FormState.tsx
@@ -91,7 +91,7 @@ export const FormState = () => {
             </SelectList>
           </Select>
 
-          <FormGroup isAction>
+          <FormGroup isActionGroup>
             <ActionList>
               <ActionListGroup>
                 <ActionListItem>

--- a/packages/react-core/src/components/LoginPage/LoginForm.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginForm.tsx
@@ -148,21 +148,23 @@ export const LoginForm: React.FunctionComponent<LoginFormProps> = ({
           />
         </FormGroup>
       )}
-      <ActionList>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button
-              variant="primary"
-              type="submit"
-              onClick={onLoginButtonClick}
-              isBlock
-              isDisabled={isLoginButtonDisabled}
-            >
-              {loginButtonLabel}
-            </Button>
-          </ActionListItem>
-        </ActionListGroup>
-      </ActionList>
+      <FormGroup isAction>
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button
+                variant="primary"
+                type="submit"
+                onClick={onLoginButtonClick}
+                isBlock
+                isDisabled={isLoginButtonDisabled}
+              >
+                {loginButtonLabel}
+              </Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </FormGroup>
     </Form>
   );
 };

--- a/packages/react-core/src/components/LoginPage/LoginForm.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Form, FormGroup, ActionGroup, FormHelperText } from '../Form';
+import { Form, FormGroup, FormHelperText } from '../Form';
+import { ActionList, ActionListGroup, ActionListItem } from '../ActionList';
 import { TextInput } from '../TextInput';
 import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
@@ -147,11 +148,21 @@ export const LoginForm: React.FunctionComponent<LoginFormProps> = ({
           />
         </FormGroup>
       )}
-      <ActionGroup>
-        <Button variant="primary" type="submit" onClick={onLoginButtonClick} isBlock isDisabled={isLoginButtonDisabled}>
-          {loginButtonLabel}
-        </Button>
-      </ActionGroup>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button
+              variant="primary"
+              type="submit"
+              onClick={onLoginButtonClick}
+              isBlock
+              isDisabled={isLoginButtonDisabled}
+            >
+              {loginButtonLabel}
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
     </Form>
   );
 };

--- a/packages/react-core/src/components/LoginPage/LoginForm.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { Form, FormGroup, FormHelperText } from '../Form';
-import { ActionList, ActionListGroup, ActionListItem } from '../ActionList';
 import { TextInput } from '../TextInput';
 import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
@@ -148,23 +147,9 @@ export const LoginForm: React.FunctionComponent<LoginFormProps> = ({
           />
         </FormGroup>
       )}
-      <FormGroup isAction>
-        <ActionList>
-          <ActionListGroup>
-            <ActionListItem>
-              <Button
-                variant="primary"
-                type="submit"
-                onClick={onLoginButtonClick}
-                isBlock
-                isDisabled={isLoginButtonDisabled}
-              >
-                {loginButtonLabel}
-              </Button>
-            </ActionListItem>
-          </ActionListGroup>
-        </ActionList>
-      </FormGroup>
+      <Button variant="primary" type="submit" onClick={onLoginButtonClick} isBlock isDisabled={isLoginButtonDisabled}>
+        {loginButtonLabel}
+      </Button>
     </Form>
   );
 };

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -134,13 +134,13 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-c-form__group pf-m-action"
+      class="pf-v6-c-action-list"
     >
       <div
-        class="pf-v6-c-form__group-control"
+        class="pf-v6-c-action-list__group"
       >
         <div
-          class="pf-v6-c-form__actions"
+          class="pf-v6-c-action-list__item"
         >
           <button
             class="pf-v6-c-button pf-m-primary pf-m-block"
@@ -304,13 +304,13 @@ exports[`LoginForm LoginForm with show password 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-c-form__group pf-m-action"
+      class="pf-v6-c-action-list"
     >
       <div
-        class="pf-v6-c-form__group-control"
+        class="pf-v6-c-action-list__group"
       >
         <div
-          class="pf-v6-c-form__actions"
+          class="pf-v6-c-action-list__item"
         >
           <button
             class="pf-v6-c-button pf-m-primary pf-m-block"
@@ -436,13 +436,13 @@ exports[`LoginForm should render Login form 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-c-form__group pf-m-action"
+      class="pf-v6-c-action-list"
     >
       <div
-        class="pf-v6-c-form__group-control"
+        class="pf-v6-c-action-list__group"
       >
         <div
-          class="pf-v6-c-form__actions"
+          class="pf-v6-c-action-list__item"
         >
           <button
             class="pf-v6-c-button pf-m-primary pf-m-block"

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
 <DocumentFragment>
   <form
     class="pf-v6-c-form"
-    data-ouia-component-id="OUIA-Generated-Form-:r1k:"
+    data-ouia-component-id="OUIA-Generated-Form-:r1s:"
     data-ouia-component-type="PF6/Form"
     data-ouia-safe="true"
     novalidate=""
   >
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r1l:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r1t:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -44,7 +44,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
         >
           <input
             aria-invalid="false"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-:r1o:"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-:r20:"
             data-ouia-component-type="PF6/TextInput"
             data-ouia-safe="true"
             id="pf-login-username-id"
@@ -58,7 +58,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
     </div>
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r1p:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r21:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -91,7 +91,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
         >
           <input
             aria-invalid="false"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-:r1s:"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-:r24:"
             data-ouia-component-type="PF6/TextInput"
             data-ouia-safe="true"
             id="pf-login-password-id"
@@ -105,7 +105,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
     </div>
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r1t:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r25:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -118,7 +118,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
           <input
             aria-invalid="false"
             class="pf-v6-c-check__input"
-            data-ouia-component-id="OUIA-Generated-Checkbox-:r20:"
+            data-ouia-component-id="OUIA-Generated-Checkbox-:r28:"
             data-ouia-component-type="PF6/Checkbox"
             data-ouia-safe="true"
             id="pf-login-remember-me-id"
@@ -134,27 +134,38 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-c-action-list"
+      class="pf-v6-c-form__group pf-m-action"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r29:"
+      data-ouia-component-type="PF6/FormGroup"
+      data-ouia-safe="true"
     >
       <div
-        class="pf-v6-c-action-list__group"
+        class="pf-v6-c-form__group-control"
       >
         <div
-          class="pf-v6-c-action-list__item"
+          class="pf-v6-c-action-list"
         >
-          <button
-            class="pf-v6-c-button pf-m-primary pf-m-block"
-            data-ouia-component-id="OUIA-Generated-Button-primary-:r21:"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe="true"
-            type="submit"
+          <div
+            class="pf-v6-c-action-list__group"
           >
-            <span
-              class="pf-v6-c-button__text"
+            <div
+              class="pf-v6-c-action-list__item"
             >
-              Log In
-            </span>
-          </button>
+              <button
+                class="pf-v6-c-button pf-m-primary pf-m-block"
+                data-ouia-component-id="OUIA-Generated-Button-primary-:r2b:"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="submit"
+              >
+                <span
+                  class="pf-v6-c-button__text"
+                >
+                  Log In
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -166,14 +177,14 @@ exports[`LoginForm LoginForm with show password 1`] = `
 <DocumentFragment>
   <form
     class="pf-v6-c-form"
-    data-ouia-component-id="OUIA-Generated-Form-:r22:"
+    data-ouia-component-id="OUIA-Generated-Form-:r2c:"
     data-ouia-component-type="PF6/Form"
     data-ouia-safe="true"
     novalidate=""
   >
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r23:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r2d:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -206,7 +217,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
         >
           <input
             aria-invalid="false"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-:r26:"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-:r2g:"
             data-ouia-component-type="PF6/TextInput"
             data-ouia-safe="true"
             id="pf-login-username-id"
@@ -220,7 +231,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
     </div>
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r27:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r2h:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -259,7 +270,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
             >
               <input
                 aria-invalid="false"
-                data-ouia-component-id="OUIA-Generated-TextInputBase-:r2a:"
+                data-ouia-component-id="OUIA-Generated-TextInputBase-:r2k:"
                 data-ouia-component-type="PF6/TextInput"
                 data-ouia-safe="true"
                 id="pf-login-password-id"
@@ -276,7 +287,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
             <button
               aria-label="Show password"
               class="pf-v6-c-button pf-m-control"
-              data-ouia-component-id="OUIA-Generated-Button-control-:r2b:"
+              data-ouia-component-id="OUIA-Generated-Button-control-:r2l:"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               type="button"
@@ -304,27 +315,38 @@ exports[`LoginForm LoginForm with show password 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-c-action-list"
+      class="pf-v6-c-form__group pf-m-action"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r2m:"
+      data-ouia-component-type="PF6/FormGroup"
+      data-ouia-safe="true"
     >
       <div
-        class="pf-v6-c-action-list__group"
+        class="pf-v6-c-form__group-control"
       >
         <div
-          class="pf-v6-c-action-list__item"
+          class="pf-v6-c-action-list"
         >
-          <button
-            class="pf-v6-c-button pf-m-primary pf-m-block"
-            data-ouia-component-id="OUIA-Generated-Button-primary-:r2c:"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe="true"
-            type="submit"
+          <div
+            class="pf-v6-c-action-list__group"
           >
-            <span
-              class="pf-v6-c-button__text"
+            <div
+              class="pf-v6-c-action-list__item"
             >
-              Log In
-            </span>
-          </button>
+              <button
+                class="pf-v6-c-button pf-m-primary pf-m-block"
+                data-ouia-component-id="OUIA-Generated-Button-primary-:r2o:"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="submit"
+              >
+                <span
+                  class="pf-v6-c-button__text"
+                >
+                  Log In
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -436,27 +458,38 @@ exports[`LoginForm should render Login form 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-c-action-list"
+      class="pf-v6-c-form__group pf-m-action"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r9:"
+      data-ouia-component-type="PF6/FormGroup"
+      data-ouia-safe="true"
     >
       <div
-        class="pf-v6-c-action-list__group"
+        class="pf-v6-c-form__group-control"
       >
         <div
-          class="pf-v6-c-action-list__item"
+          class="pf-v6-c-action-list"
         >
-          <button
-            class="pf-v6-c-button pf-m-primary pf-m-block"
-            data-ouia-component-id="OUIA-Generated-Button-primary-:r9:"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe="true"
-            type="submit"
+          <div
+            class="pf-v6-c-action-list__group"
           >
-            <span
-              class="pf-v6-c-button__text"
+            <div
+              class="pf-v6-c-action-list__item"
             >
-              Log In
-            </span>
-          </button>
+              <button
+                class="pf-v6-c-button pf-m-primary pf-m-block"
+                data-ouia-component-id="OUIA-Generated-Button-primary-:rb:"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="submit"
+              >
+                <span
+                  class="pf-v6-c-button__text"
+                >
+                  Log In
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
 <DocumentFragment>
   <form
     class="pf-v6-c-form"
-    data-ouia-component-id="OUIA-Generated-Form-:r1s:"
+    data-ouia-component-id="OUIA-Generated-Form-:r1k:"
     data-ouia-component-type="PF6/Form"
     data-ouia-safe="true"
     novalidate=""
   >
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r1t:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r1l:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -44,7 +44,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
         >
           <input
             aria-invalid="false"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-:r20:"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-:r1o:"
             data-ouia-component-type="PF6/TextInput"
             data-ouia-safe="true"
             id="pf-login-username-id"
@@ -58,7 +58,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
     </div>
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r21:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r1p:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -91,7 +91,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
         >
           <input
             aria-invalid="false"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-:r24:"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-:r1s:"
             data-ouia-component-type="PF6/TextInput"
             data-ouia-safe="true"
             id="pf-login-password-id"
@@ -105,7 +105,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
     </div>
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r25:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r1t:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -118,7 +118,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
           <input
             aria-invalid="false"
             class="pf-v6-c-check__input"
-            data-ouia-component-id="OUIA-Generated-Checkbox-:r28:"
+            data-ouia-component-id="OUIA-Generated-Checkbox-:r20:"
             data-ouia-component-type="PF6/Checkbox"
             data-ouia-safe="true"
             id="pf-login-remember-me-id"
@@ -133,42 +133,19 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="pf-v6-c-form__group pf-m-action"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r29:"
-      data-ouia-component-type="PF6/FormGroup"
+    <button
+      class="pf-v6-c-button pf-m-primary pf-m-block"
+      data-ouia-component-id="OUIA-Generated-Button-primary-:r21:"
+      data-ouia-component-type="PF6/Button"
       data-ouia-safe="true"
+      type="submit"
     >
-      <div
-        class="pf-v6-c-form__group-control"
+      <span
+        class="pf-v6-c-button__text"
       >
-        <div
-          class="pf-v6-c-action-list"
-        >
-          <div
-            class="pf-v6-c-action-list__group"
-          >
-            <div
-              class="pf-v6-c-action-list__item"
-            >
-              <button
-                class="pf-v6-c-button pf-m-primary pf-m-block"
-                data-ouia-component-id="OUIA-Generated-Button-primary-:r2b:"
-                data-ouia-component-type="PF6/Button"
-                data-ouia-safe="true"
-                type="submit"
-              >
-                <span
-                  class="pf-v6-c-button__text"
-                >
-                  Log In
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+        Log In
+      </span>
+    </button>
   </form>
 </DocumentFragment>
 `;
@@ -177,14 +154,14 @@ exports[`LoginForm LoginForm with show password 1`] = `
 <DocumentFragment>
   <form
     class="pf-v6-c-form"
-    data-ouia-component-id="OUIA-Generated-Form-:r2c:"
+    data-ouia-component-id="OUIA-Generated-Form-:r22:"
     data-ouia-component-type="PF6/Form"
     data-ouia-safe="true"
     novalidate=""
   >
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r2d:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r23:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -217,7 +194,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
         >
           <input
             aria-invalid="false"
-            data-ouia-component-id="OUIA-Generated-TextInputBase-:r2g:"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-:r26:"
             data-ouia-component-type="PF6/TextInput"
             data-ouia-safe="true"
             id="pf-login-username-id"
@@ -231,7 +208,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
     </div>
     <div
       class="pf-v6-c-form__group"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r2h:"
+      data-ouia-component-id="OUIA-Generated-FormGroup-:r27:"
       data-ouia-component-type="PF6/FormGroup"
       data-ouia-safe="true"
     >
@@ -270,7 +247,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
             >
               <input
                 aria-invalid="false"
-                data-ouia-component-id="OUIA-Generated-TextInputBase-:r2k:"
+                data-ouia-component-id="OUIA-Generated-TextInputBase-:r2a:"
                 data-ouia-component-type="PF6/TextInput"
                 data-ouia-safe="true"
                 id="pf-login-password-id"
@@ -287,7 +264,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
             <button
               aria-label="Show password"
               class="pf-v6-c-button pf-m-control"
-              data-ouia-component-id="OUIA-Generated-Button-control-:r2l:"
+              data-ouia-component-id="OUIA-Generated-Button-control-:r2b:"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               type="button"
@@ -314,42 +291,19 @@ exports[`LoginForm LoginForm with show password 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="pf-v6-c-form__group pf-m-action"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r2m:"
-      data-ouia-component-type="PF6/FormGroup"
+    <button
+      class="pf-v6-c-button pf-m-primary pf-m-block"
+      data-ouia-component-id="OUIA-Generated-Button-primary-:r2c:"
+      data-ouia-component-type="PF6/Button"
       data-ouia-safe="true"
+      type="submit"
     >
-      <div
-        class="pf-v6-c-form__group-control"
+      <span
+        class="pf-v6-c-button__text"
       >
-        <div
-          class="pf-v6-c-action-list"
-        >
-          <div
-            class="pf-v6-c-action-list__group"
-          >
-            <div
-              class="pf-v6-c-action-list__item"
-            >
-              <button
-                class="pf-v6-c-button pf-m-primary pf-m-block"
-                data-ouia-component-id="OUIA-Generated-Button-primary-:r2o:"
-                data-ouia-component-type="PF6/Button"
-                data-ouia-safe="true"
-                type="submit"
-              >
-                <span
-                  class="pf-v6-c-button__text"
-                >
-                  Log In
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+        Log In
+      </span>
+    </button>
   </form>
 </DocumentFragment>
 `;
@@ -457,42 +411,19 @@ exports[`LoginForm should render Login form 1`] = `
         </span>
       </div>
     </div>
-    <div
-      class="pf-v6-c-form__group pf-m-action"
-      data-ouia-component-id="OUIA-Generated-FormGroup-:r9:"
-      data-ouia-component-type="PF6/FormGroup"
+    <button
+      class="pf-v6-c-button pf-m-primary pf-m-block"
+      data-ouia-component-id="OUIA-Generated-Button-primary-:r9:"
+      data-ouia-component-type="PF6/Button"
       data-ouia-safe="true"
+      type="submit"
     >
-      <div
-        class="pf-v6-c-form__group-control"
+      <span
+        class="pf-v6-c-button__text"
       >
-        <div
-          class="pf-v6-c-action-list"
-        >
-          <div
-            class="pf-v6-c-action-list__group"
-          >
-            <div
-              class="pf-v6-c-action-list__item"
-            >
-              <button
-                class="pf-v6-c-button pf-m-primary pf-m-block"
-                data-ouia-component-id="OUIA-Generated-Button-primary-:rb:"
-                data-ouia-component-type="PF6/Button"
-                data-ouia-safe="true"
-                type="submit"
-              >
-                <span
-                  class="pf-v6-c-button__text"
-                >
-                  Log In
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+        Log In
+      </span>
+    </button>
   </form>
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/SearchInput/AdvancedSearchMenu.tsx
+++ b/packages/react-core/src/components/SearchInput/AdvancedSearchMenu.tsx
@@ -203,22 +203,24 @@ export const AdvancedSearchMenu: React.FunctionComponent<AdvancedSearchMenuProps
           <Form>
             {buildFormGroups()}
             {formAdditionalItems ? formAdditionalItems : null}
-            <ActionList>
-              <ActionListGroup>
-                <ActionListItem>
-                  <Button variant="primary" type="submit" onClick={onSearchHandler} isDisabled={!value}>
-                    {submitSearchButtonLabel}
-                  </Button>
-                </ActionListItem>
-                {!!onClear && (
+            <FormGroup isAction>
+              <ActionList>
+                <ActionListGroup>
                   <ActionListItem>
-                    <Button variant="link" type="reset" onClick={onClear}>
-                      {resetButtonLabel}
+                    <Button variant="primary" type="submit" onClick={onSearchHandler} isDisabled={!value}>
+                      {submitSearchButtonLabel}
                     </Button>
                   </ActionListItem>
-                )}
-              </ActionListGroup>
-            </ActionList>
+                  {!!onClear && (
+                    <ActionListItem>
+                      <Button variant="link" type="reset" onClick={onClear}>
+                        {resetButtonLabel}
+                      </Button>
+                    </ActionListItem>
+                  )}
+                </ActionListGroup>
+              </ActionList>
+            </FormGroup>
           </Form>
         </PanelMainBody>
       </PanelMain>

--- a/packages/react-core/src/components/SearchInput/AdvancedSearchMenu.tsx
+++ b/packages/react-core/src/components/SearchInput/AdvancedSearchMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '../Button';
-import { ActionGroup, Form, FormGroup } from '../Form';
+import { ActionList, ActionListGroup, ActionListItem } from '../ActionList';
+import { Form, FormGroup } from '../Form';
 import { TextInput } from '../TextInput';
 import { useSSRSafeId } from '../../helpers';
 import { SearchInputSearchAttribute } from './SearchInput';
@@ -202,16 +203,22 @@ export const AdvancedSearchMenu: React.FunctionComponent<AdvancedSearchMenuProps
           <Form>
             {buildFormGroups()}
             {formAdditionalItems ? formAdditionalItems : null}
-            <ActionGroup>
-              <Button variant="primary" type="submit" onClick={onSearchHandler} isDisabled={!value}>
-                {submitSearchButtonLabel}
-              </Button>
-              {!!onClear && (
-                <Button variant="link" type="reset" onClick={onClear}>
-                  {resetButtonLabel}
-                </Button>
-              )}
-            </ActionGroup>
+            <ActionList>
+              <ActionListGroup>
+                <ActionListItem>
+                  <Button variant="primary" type="submit" onClick={onSearchHandler} isDisabled={!value}>
+                    {submitSearchButtonLabel}
+                  </Button>
+                </ActionListItem>
+                {!!onClear && (
+                  <ActionListItem>
+                    <Button variant="link" type="reset" onClick={onClear}>
+                      {resetButtonLabel}
+                    </Button>
+                  </ActionListItem>
+                )}
+              </ActionListGroup>
+            </ActionList>
           </Form>
         </PanelMainBody>
       </PanelMain>

--- a/packages/react-core/src/components/SearchInput/AdvancedSearchMenu.tsx
+++ b/packages/react-core/src/components/SearchInput/AdvancedSearchMenu.tsx
@@ -203,7 +203,7 @@ export const AdvancedSearchMenu: React.FunctionComponent<AdvancedSearchMenuProps
           <Form>
             {buildFormGroups()}
             {formAdditionalItems ? formAdditionalItems : null}
-            <FormGroup isAction>
+            <FormGroup isActionGroup>
               <ActionList>
                 <ActionListGroup>
                   <ActionListItem>

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -436,13 +436,13 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                 </div>
               </div>
               <div
-                class="pf-v6-c-form__group pf-m-action"
+                class="pf-v6-c-action-list"
               >
                 <div
-                  class="pf-v6-c-form__group-control"
+                  class="pf-v6-c-action-list__group"
                 >
                   <div
-                    class="pf-v6-c-form__actions"
+                    class="pf-v6-c-action-list__item"
                   >
                     <button
                       class="pf-v6-c-button pf-m-primary"
@@ -454,6 +454,10 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                         Search
                       </span>
                     </button>
+                  </div>
+                  <div
+                    class="pf-v6-c-action-list__item"
+                  >
                     <button
                       class="pf-v6-c-button pf-m-link"
                       type="reset"

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -436,38 +436,46 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                 </div>
               </div>
               <div
-                class="pf-v6-c-action-list"
+                class="pf-v6-c-form__group pf-m-action"
               >
                 <div
-                  class="pf-v6-c-action-list__group"
+                  class="pf-v6-c-form__group-control"
                 >
                   <div
-                    class="pf-v6-c-action-list__item"
+                    class="pf-v6-c-action-list"
                   >
-                    <button
-                      class="pf-v6-c-button pf-m-primary"
-                      type="submit"
+                    <div
+                      class="pf-v6-c-action-list__group"
                     >
-                      <span
-                        class="pf-v6-c-button__text"
+                      <div
+                        class="pf-v6-c-action-list__item"
                       >
-                        Search
-                      </span>
-                    </button>
-                  </div>
-                  <div
-                    class="pf-v6-c-action-list__item"
-                  >
-                    <button
-                      class="pf-v6-c-button pf-m-link"
-                      type="reset"
-                    >
-                      <span
-                        class="pf-v6-c-button__text"
+                        <button
+                          class="pf-v6-c-button pf-m-primary"
+                          type="submit"
+                        >
+                          <span
+                            class="pf-v6-c-button__text"
+                          >
+                            Search
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="pf-v6-c-action-list__item"
                       >
-                        Reset
-                      </span>
-                    </button>
+                        <button
+                          class="pf-v6-c-button pf-m-link"
+                          type="reset"
+                        >
+                          <span
+                            class="pf-v6-c-button__text"
+                          >
+                            Reset
+                          </span>
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/react-core/src/demos/Button/examples/ButtonProgress.tsx
+++ b/packages/react-core/src/demos/Button/examples/ButtonProgress.tsx
@@ -35,32 +35,34 @@ export const ButtonProgress: React.FunctionComponent = () => {
           aria-label="password input"
         />
       </FormGroup>
-      <ActionList>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button
-              variant="primary"
-              onClick={
-                loginState === 'notLoggedIn'
-                  ? () => {
-                      setLoginState('loading');
-                      setTimeout(() => {
-                        setLoginState('loggedIn');
-                      }, 3000);
-                    }
-                  : null
-              }
-              isLoading={loginState === 'loading'}
-              icon={loginState === 'loggedIn' ? <RhUiCheckCircleFillIcon /> : null}
-              spinnerAriaValueText="Loading..."
-            >
-              {loginState === 'notLoggedIn' && 'Link account and log in'}
-              {loginState === 'loading' && 'Linking account'}
-              {loginState === 'loggedIn' && 'Logged in'}
-            </Button>
-          </ActionListItem>
-        </ActionListGroup>
-      </ActionList>
+      <FormGroup isAction>
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button
+                variant="primary"
+                onClick={
+                  loginState === 'notLoggedIn'
+                    ? () => {
+                        setLoginState('loading');
+                        setTimeout(() => {
+                          setLoginState('loggedIn');
+                        }, 3000);
+                      }
+                    : null
+                }
+                isLoading={loginState === 'loading'}
+                icon={loginState === 'loggedIn' ? <RhUiCheckCircleFillIcon /> : null}
+                spinnerAriaValueText="Loading..."
+              >
+                {loginState === 'notLoggedIn' && 'Link account and log in'}
+                {loginState === 'loading' && 'Linking account'}
+                {loginState === 'loggedIn' && 'Logged in'}
+              </Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </FormGroup>
     </Form>
   );
 };

--- a/packages/react-core/src/demos/Button/examples/ButtonProgress.tsx
+++ b/packages/react-core/src/demos/Button/examples/ButtonProgress.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
-import { Form, FormGroup, ActionGroup, TextInput, Button } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Button,
+  ActionListItem,
+  ActionListGroup,
+  ActionList
+} from '@patternfly/react-core';
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 
 export const ButtonProgress: React.FunctionComponent = () => {
@@ -27,28 +35,32 @@ export const ButtonProgress: React.FunctionComponent = () => {
           aria-label="password input"
         />
       </FormGroup>
-      <ActionGroup>
-        <Button
-          variant="primary"
-          onClick={
-            loginState === 'notLoggedIn'
-              ? () => {
-                  setLoginState('loading');
-                  setTimeout(() => {
-                    setLoginState('loggedIn');
-                  }, 3000);
-                }
-              : null
-          }
-          isLoading={loginState === 'loading'}
-          icon={loginState === 'loggedIn' ? <RhUiCheckCircleFillIcon /> : null}
-          spinnerAriaValueText="Loading..."
-        >
-          {loginState === 'notLoggedIn' && 'Link account and log in'}
-          {loginState === 'loading' && 'Linking account'}
-          {loginState === 'loggedIn' && 'Logged in'}
-        </Button>
-      </ActionGroup>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button
+              variant="primary"
+              onClick={
+                loginState === 'notLoggedIn'
+                  ? () => {
+                      setLoginState('loading');
+                      setTimeout(() => {
+                        setLoginState('loggedIn');
+                      }, 3000);
+                    }
+                  : null
+              }
+              isLoading={loginState === 'loading'}
+              icon={loginState === 'loggedIn' ? <RhUiCheckCircleFillIcon /> : null}
+              spinnerAriaValueText="Loading..."
+            >
+              {loginState === 'notLoggedIn' && 'Link account and log in'}
+              {loginState === 'loading' && 'Linking account'}
+              {loginState === 'loggedIn' && 'Logged in'}
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
     </Form>
   );
 };

--- a/packages/react-core/src/demos/Button/examples/ButtonProgress.tsx
+++ b/packages/react-core/src/demos/Button/examples/ButtonProgress.tsx
@@ -35,7 +35,7 @@ export const ButtonProgress: React.FunctionComponent = () => {
           aria-label="password input"
         />
       </FormGroup>
-      <FormGroup isAction>
+      <FormGroup isActionGroup>
         <ActionList>
           <ActionListGroup>
             <ActionListItem>

--- a/packages/react-core/src/demos/SearchInput/examples/SearchInputAdvancedComposable.tsx
+++ b/packages/react-core/src/demos/SearchInput/examples/SearchInputAdvancedComposable.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import {
-  ActionGroup,
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
   Button,
   DatePicker,
   Form,
@@ -290,16 +292,22 @@ export const SearchInputAdvancedComposable: React.FunctionComponent = () => {
                   </FormGroup>
                 </GridItem>
               </Grid>
-              <ActionGroup>
-                <Button variant="primary" type="submit" onClick={(e) => onSubmit(null, e)}>
-                  Submit
-                </Button>
-                {!!onClear && (
-                  <Button variant="link" type="reset" onClick={onClear}>
-                    Reset
-                  </Button>
-                )}
-              </ActionGroup>
+              <ActionList>
+                <ActionListGroup>
+                  <ActionListItem>
+                    <Button variant="primary" type="submit" onClick={(e) => onSubmit(null, e)}>
+                      Submit
+                    </Button>
+                  </ActionListItem>
+                  <ActionListItem>
+                    {!!onClear && (
+                      <Button variant="link" type="reset" onClick={onClear}>
+                        Reset
+                      </Button>
+                    )}
+                  </ActionListItem>
+                </ActionListGroup>
+              </ActionList>
             </Form>
           </PanelMainBody>
         </PanelMain>

--- a/packages/react-core/src/demos/SearchInput/examples/SearchInputAdvancedComposable.tsx
+++ b/packages/react-core/src/demos/SearchInput/examples/SearchInputAdvancedComposable.tsx
@@ -292,22 +292,24 @@ export const SearchInputAdvancedComposable: React.FunctionComponent = () => {
                   </FormGroup>
                 </GridItem>
               </Grid>
-              <ActionList>
-                <ActionListGroup>
-                  <ActionListItem>
-                    <Button variant="primary" type="submit" onClick={(e) => onSubmit(null, e)}>
-                      Submit
-                    </Button>
-                  </ActionListItem>
-                  <ActionListItem>
-                    {!!onClear && (
-                      <Button variant="link" type="reset" onClick={onClear}>
-                        Reset
+              <FormGroup isAction>
+                <ActionList>
+                  <ActionListGroup>
+                    <ActionListItem>
+                      <Button variant="primary" type="submit" onClick={(e) => onSubmit(null, e)}>
+                        Submit
                       </Button>
-                    )}
-                  </ActionListItem>
-                </ActionListGroup>
-              </ActionList>
+                    </ActionListItem>
+                    <ActionListItem>
+                      {!!onClear && (
+                        <Button variant="link" type="reset" onClick={onClear}>
+                          Reset
+                        </Button>
+                      )}
+                    </ActionListItem>
+                  </ActionListGroup>
+                </ActionList>
+              </FormGroup>
             </Form>
           </PanelMainBody>
         </PanelMain>

--- a/packages/react-integration/cypress/integration/searchinput.spec.ts
+++ b/packages/react-integration/cypress/integration/searchinput.spec.ts
@@ -62,13 +62,13 @@ describe('Search Input Demo Test', () => {
     cy.get('#enabled-search .pf-v6-c-form-control > input').eq(1).should('have.value', 'hi');
     cy.get('#enabled-search .pf-v6-c-form-control > input').eq(2).should('have.value', 'another test');
 
-    cy.get('#enabled-search .pf-v6-c-form__actions button').eq(1).click({ force: true });
+    cy.get('#enabled-search .pf-v6-c-action-list button').eq(1).click({ force: true });
     cy.get('#enabled-search .pf-v6-c-text-input-group__text-input').should('have.value', '');
     cy.get('#enabled-search .pf-v6-c-form-control > input').eq(1).should('have.value', '');
     cy.get('#enabled-search .pf-v6-c-form-control > input').eq(2).should('have.value', '');
 
     cy.get('#enabled-search .pf-v6-c-form-control > input').eq(0).type('test');
-    cy.get('#enabled-search .pf-v6-c-form__actions button').eq(0).click({ force: true });
+    cy.get('#enabled-search .pf-v6-c-action-list button').eq(0).click({ force: true });
     cy.get('#enabled-search .pf-v6-c-form input').should('not.exist');
     cy.get('#enabled-search .pf-v6-c-text-input-group__text-input').should('have.value', 'username:test');
   });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Part of https://github.com/patternfly/patternfly/issues/8486

This button went from full-width to not (I didn't see a prop for this):
http://localhost:8002/components/login-page/react/basic

Others have slight spacing changes above or horizontally, but tabbing looks better.

I didn't see any internal usage in form, but we use the action group naming convention in certain styles, etc.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
https://github.com/patternfly/patternfly/pull/8527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated Form documentation to include additional action list components.

* **New Features**
  * Added `isActionGroup?: boolean` to `FormGroup` to enable the action styling variant.

* **Refactor**
  * Migrated Form, login, search, and button examples (including demos) from `ActionGroup` to the `ActionList` structure, keeping labels, behavior, validation, loading states, and conditional rendering the same.

* **Deprecation**
  * Deprecated `ActionGroupProps` in favor of `ActionList`, `ActionListGroup`, and `ActionListItem`.

* **Tests**
  * Updated Cypress selectors for advanced search action buttons to match the new action list structure.
  * Added a unit test to verify `FormGroup` action styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->