### PR TITLE
fix(JumpLinks): updated demo code for active item

### DIFF
--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -142,6 +142,10 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
       return;
     }
     const scrollPosition = Math.ceil(scrollableElement.scrollTop + offset);
+    // Take into account the last section not having enough content to trigger a scroll position; without
+    // checking if at the bottom of the scroll container, the last JumpLinksItem never becomes "active".
+    const isAtBottom =
+      Math.ceil(scrollableElement.scrollTop + scrollableElement.clientHeight) >= scrollableElement.scrollHeight;
     window.requestAnimationFrame(() => {
       let newScrollItems = scrollItems;
       // Items might have rendered after this component or offsetTop values may need
@@ -151,6 +155,11 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
       if (requiresRefresh) {
         newScrollItems = getScrollItems(children, []);
         setScrollItems(newScrollItems);
+      }
+
+      if (isAtBottom) {
+        const lastIndex = newScrollItems.length - 1;
+        return setActiveIndex(lastIndex);
       }
 
       const scrollElements = newScrollItems

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksScrollspy.tsx
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksScrollspy.tsx
@@ -72,7 +72,7 @@ export const JumpLinksScrollspy: React.FunctionComponent = () => {
                 isVertical={isVertical}
                 isCentered={!isVertical}
                 label="Jump to section"
-                scrollableSelector=".pf-v6-c-page__main-container"
+                scrollableSelector=".pf-v6-c-page__main"
                 offset={offsetHeight}
                 expandable={{ default: isVertical ? 'expandable' : 'nonExpandable', md: 'nonExpandable' }}
                 isExpanded


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12223

Also added additional line of logic for an issue I was noticing for scrollspy demos (last jump link item not becoming "current" if that section didn't have enough content).

@edewit I noticed the Keycloak issue referenced in the above PF issue that y'all may have implemented a fix for the issue? FWIW i believe the original issue may have been because the scrollable page container was no longer accurate; we now have the `.pf-v6-c-page__main` selector as the scrollable container, not `.pf-v6-c-page__main-container` (which both one of our demos that were broken as well as Keycloak were originally using, at least based on Keycloak PR 47651).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Jump Links scroll-spy behavior so the final link becomes active when scrolling to the bottom of a page.
  * Updated the scroll target used by the Jump Links example for more accurate active-link tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->