### PR TITLE
fix(Popover): fixed focus trapped on hoverable trigger

### DIFF
--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -207,7 +207,9 @@ export interface PopoverProps {
   showClose?: boolean;
   /** Sets an interaction to open popover, defaults to "click" */
   triggerAction?: 'click' | 'hover';
-  /** Whether to trap focus in the popover. */
+  /** Whether to trap focus in the popover. When using a triggerAction of "hover", this will be set to false
+   * by default and must remain false.
+   */
   withFocusTrap?: boolean;
   /** The z-index of the popover. */
   zIndex?: number;
@@ -267,7 +269,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   ],
   animationDuration = 300,
   id,
-  withFocusTrap: propWithFocusTrap,
+  withFocusTrap: propWithFocusTrap = triggerAction === 'hover' ? false : undefined,
   triggerRef,
   hasNoPadding = false,
   hasAutoWidth = false,

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -205,7 +205,7 @@ export interface PopoverProps {
   shouldOpen?: (event: MouseEvent | KeyboardEvent, showFunction?: () => void) => void;
   /** Flag indicating whether the close button should be shown. */
   showClose?: boolean;
-  /** Sets an interaction to open popover, defaults to "click" */
+  /** @deprecated Sets an interaction to open popover, defaults to "click" */
   triggerAction?: 'click' | 'hover';
   /** Whether to trap focus in the popover. When using a triggerAction of "hover", this will be set to false
    * by default and must remain false.

--- a/packages/react-core/src/components/Popover/examples/Popover.md
+++ b/packages/react-core/src/components/Popover/examples/Popover.md
@@ -25,6 +25,8 @@ By default, the `appendTo` prop of the popover will append to the document body 
 
 ### Hoverable
 
+Pass the `triggerAction="hover"` property to make a `<Popover>` that is triggered via hover and focus rather than on click. When using a hoverable Popover, you **must not** include any interactive or semantic content (e.g. buttons, links, headings, lists, etc), as focus is not intended to enter a hoverable `<Popover>`. Including such content may cause an inaccessible UI for users who are not able to reach the content when navigating via assistive tech.
+
 ```ts file="./PopoverHover.tsx"
 
 ```

--- a/packages/react-core/src/components/Popover/examples/Popover.md
+++ b/packages/react-core/src/components/Popover/examples/Popover.md
@@ -27,7 +27,9 @@ By default, the `appendTo` prop of the popover will append to the document body 
 
 Pass the `triggerAction="hover"` property to make a `<Popover>` that is triggered via hover and focus rather than on click. When using a hoverable Popover, you **must not** include any interactive or semantic content (e.g. buttons, links, headings, lists, etc), as focus is not intended to enter a hoverable `<Popover>`. Including such content may cause an inaccessible UI for users who are not able to reach the content when navigating via assistive tech.
 
-```ts file="./PopoverHover.tsx"
+It is instead recommended to use our [tooltip component](/components/tooltip).
+
+```ts isDeprecated file="./PopoverHover.tsx"
 
 ```
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10257

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented focus trapping from being enabled by default for hover-triggered popovers, aligning focus behavior with expected hover interactions.

* **Documentation**
  * Updated the “Hoverable” popover example to explicitly use `triggerAction="hover"` for hover-based behavior.
  * Added accessibility guidance warning that hoverable popovers should not include interactive/semantic content since focus is not intended to enter that area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->