### PR TITLE
fix(workflow): fix release deploy

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,7 +45,7 @@ jobs:
           ref: refs/pull/${{ env.GH_PR_NUM }}/head
 
       - name: Check out project
-        if: inputs.is-release || (github.event_name != 'pull_request_target' && github.event_name != 'issue_comment')
+        if: inputs.is-release || github.event_name == 'workflow_call'
         uses: actions/checkout@v4
       - name: Set up and build project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,7 +45,7 @@ jobs:
           ref: refs/pull/${{ env.GH_PR_NUM }}/head
 
       - name: Check out project
-        if: inputs.is-release
+        if: inputs.is-release || (github.event_name != 'pull_request_target' && github.event_name != 'issue_comment')
         uses: actions/checkout@v4
       - name: Set up and build project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,12 @@ on:
   issue_comment:
     types: [created]
   workflow_call:
+    inputs:
+      is-release:
+        description: Whether this is invoked from the Release workflow (skip PR permission gating).
+        type: boolean
+        required: false
+        default: false
     secrets:
       SURGE_LOGIN:
         required: true
@@ -23,7 +29,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      (github.event_name == 'workflow_call' || needs.check-permissions.outputs.allowed == 'true')
+      (inputs.is-release || needs.check-permissions.outputs.allowed == 'true')
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -39,7 +45,7 @@ jobs:
           ref: refs/pull/${{ env.GH_PR_NUM }}/head
 
       - name: Check out project
-        if: github.event_name == 'workflow_call'
+        if: inputs.is-release
         uses: actions/checkout@v4
       - name: Set up and build project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   docs:
     name: Documentation
     uses: ./.github/workflows/documentation.yml
+    with:
+      is-release: true
     secrets: inherit
 
   deploy:


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12540

It seems that `github.event_name == 'workflow_call'` doesn't return true when the release workflow steps run (event_name evaluates to 'push'). Refactored to instead explicitly pipe a flag for the release workflow.

Assisted by Cursor AI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documentation deployments triggered during releases can now proceed through the release workflow without requiring the usual pull request permission check.
  * Standard documentation deployments continue to use the existing permission validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->