### PR TITLE
feat(Slider): Recognize localized number input

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -7,7 +7,7 @@ import { TextInput } from '../TextInput';
 import { Tooltip, TooltipProps } from '../Tooltip';
 import cssSliderValue from '@patternfly/react-tokens/dist/esm/c_slider_value';
 import cssFormControlWidthChars from '@patternfly/react-tokens/dist/esm/c_slider__value_c_form_control_width_chars';
-import { getLanguageDirection } from '../../helpers/util';
+import { formatLocalizedDecimal, getLanguageDirection, parseLocalizedDecimal } from '../../helpers/util';
 
 /** Properties for creating custom steps in a slider. These properties should be passed in as
  * an object within an array to the slider component's customSteps property.
@@ -93,6 +93,8 @@ export interface SliderProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onCh
   thumbAriaValueText?: string;
   /** Current value of the slider.  */
   value?: number;
+  /** Locale string used for input formatting and parsing. See https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag for more information. */
+  locale?: string;
 }
 
 const getPercentage = (current: number, max: number) => (100 * current) / max;
@@ -126,13 +128,22 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   showBoundaries = true,
   'aria-describedby': ariaDescribedby,
   'aria-labelledby': ariaLabelledby,
+  locale,
   ...props
 }: SliderProps) => {
   const sliderRailRef = useRef<HTMLDivElement>(undefined);
   const thumbRef = useRef<HTMLDivElement>(undefined);
+  const isInputFocusedRef = useRef(false);
+  let formatter: Intl.NumberFormat;
+  try {
+    formatter = new Intl.NumberFormat(locale);
+  } catch {
+    formatter = new Intl.NumberFormat(); // grabs default locale
+  }
 
   const [localValue, setValue] = useState(value);
   const [localInputValue, setLocalInputValue] = useState(inputValue);
+  const [inputDisplayValue, setInputDisplayValue] = useState(() => formatLocalizedDecimal(inputValue, formatter));
 
   let isRTL: boolean;
 
@@ -144,9 +155,45 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     setValue(value);
   }, [value]);
 
+  const updateInputDisplay = useCallback((numericValue: number) => {
+    setInputDisplayValue(formatLocalizedDecimal(numericValue, formatter));
+  }, []);
+
+  const updateInputFromSliderValue = useCallback(
+    (numericValue: number) => {
+      if (!isInputVisible) {
+        return;
+      }
+
+      setLocalInputValue(numericValue);
+      if (!isInputFocusedRef.current) {
+        updateInputDisplay(numericValue);
+      }
+    },
+    [isInputVisible, updateInputDisplay]
+  );
+
+  const setLocalInputValueWithDisplay = useCallback<React.Dispatch<React.SetStateAction<number>>>(
+    (nextValue) => {
+      setLocalInputValue((previousValue) => {
+        const resolvedValue = typeof nextValue === 'function' ? nextValue(previousValue) : nextValue;
+
+        if (!isInputFocusedRef.current) {
+          updateInputDisplay(resolvedValue);
+        }
+
+        return resolvedValue;
+      });
+    },
+    [updateInputDisplay]
+  );
+
   useEffect(() => {
-    setLocalInputValue(inputValue);
-  }, [inputValue]);
+    if (!isInputFocusedRef.current) {
+      setLocalInputValue(inputValue);
+      updateInputDisplay(inputValue);
+    }
+  }, [inputValue, updateInputDisplay]);
 
   let diff = 0;
   let snapValue: number;
@@ -154,27 +201,44 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   // calculate style value percentage
   const stylePercent = ((localValue - min) * 100) / (max - min);
   const style = { [cssSliderValue.name]: `${stylePercent}%` } as React.CSSProperties;
-  const widthChars = useMemo(() => localInputValue.toString().length, [localInputValue]);
+  const widthChars = useMemo(() => inputDisplayValue.length || 1, [inputDisplayValue]);
   const inputStyle = { [cssFormControlWidthChars.name]: widthChars } as React.CSSProperties;
 
   const onChangeHandler = (event: React.FormEvent<HTMLInputElement>, value: string) => {
-    const newValue = Number(value);
-    setLocalInputValue(newValue);
+    setInputDisplayValue(value);
 
-    isInputLive && onChange && onChange(event, localValue, newValue, setLocalInputValue);
+    const parsedValue = parseLocalizedDecimal(value, formatter);
+
+    if (!Number.isNaN(parsedValue)) {
+      setLocalInputValue(parsedValue);
+      isInputLive && onChange && onChange(event, localValue, parsedValue, setLocalInputValueWithDisplay);
+    }
   };
 
   const handleKeyPressOnInput = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter') {
       event.preventDefault();
+      const parsedValue = parseLocalizedDecimal(inputDisplayValue, formatter);
+
+      if (!Number.isNaN(parsedValue)) {
+        setLocalInputValue(parsedValue);
+        updateInputDisplay(parsedValue);
+      }
+
       if (onChange) {
-        onChange(event, localValue, localInputValue, setLocalInputValue);
+        onChange(
+          event,
+          localValue,
+          Number.isNaN(parsedValue) ? localInputValue : parsedValue,
+          setLocalInputValueWithDisplay
+        );
       }
     }
   };
 
-  const onInputFocus = (e: any) => {
+  const onInputFocus = (e: React.SyntheticEvent<HTMLInputElement>) => {
     e.stopPropagation();
+    isInputFocusedRef.current = true;
   };
 
   const onThumbClick = () => {
@@ -182,8 +246,16 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   };
 
   const onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    isInputFocusedRef.current = false;
+
+    const parsedValue = parseLocalizedDecimal(inputDisplayValue, formatter);
+    const resolvedInputValue = Number.isNaN(parsedValue) ? localInputValue : parsedValue;
+
+    setLocalInputValue(resolvedInputValue);
+    updateInputDisplay(resolvedInputValue);
+
     if (onChange) {
-      onChange(event, localValue, localInputValue, setLocalInputValue);
+      onChange(event, localValue, resolvedInputValue, setLocalInputValueWithDisplay);
     }
   };
 
@@ -240,8 +312,9 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     if (snapValue && !areCustomStepsContinuous) {
       thumbRef.current.style.setProperty(cssSliderValue.name, `${snapValue}%`);
       setValue(snapValue);
+      updateInputFromSliderValue(snapValue);
       if (onChange) {
-        onChange(e, snapValue);
+        onChange(e, snapValue, undefined, setLocalInputValueWithDisplay);
       }
     }
   };
@@ -308,16 +381,22 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     }
 
     // Call onchange callback
+    const resolvedValue = snapValue !== undefined ? snapValue : newValue;
+    updateInputFromSliderValue(resolvedValue);
+
     if (onChange) {
-      if (snapValue !== undefined) {
-        onChange(e, snapValue);
-      } else {
-        onChange(e, newValue);
-      }
+      onChange(e, resolvedValue, undefined, setLocalInputValueWithDisplay);
     }
   };
 
-  const callbackThumbMove = useCallback(handleThumbMove, [min, max, customSteps, onChange]);
+  const callbackThumbMove = useCallback(handleThumbMove, [
+    min,
+    max,
+    customSteps,
+    onChange,
+    updateInputFromSliderValue,
+    setLocalInputValueWithDisplay
+  ]);
   const callbackThumbUp = useCallback(handleThumbDragEnd, [min, max, customSteps, onChange]);
 
   const handleThumbKeys = (e: React.KeyboardEvent) => {
@@ -373,8 +452,9 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     if (newValue !== localValue) {
       thumbRef.current.style.setProperty(cssSliderValue.name, `${newValue}%`);
       setValue(newValue);
+      updateInputFromSliderValue(newValue);
       if (onChange) {
-        onChange(e, newValue);
+        onChange(e, newValue, undefined, setLocalInputValueWithDisplay);
       }
     }
   };
@@ -383,8 +463,9 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     const textInput = (
       <TextInput
         isDisabled={isDisabled}
-        type="number"
-        value={localInputValue}
+        type="text"
+        inputMode="decimal"
+        value={inputDisplayValue}
         aria-label={inputAriaLabel}
         onKeyDown={handleKeyPressOnInput}
         onChange={onChangeHandler}

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -7,7 +7,12 @@ import { TextInput } from '../TextInput';
 import { Tooltip, TooltipProps } from '../Tooltip';
 import cssSliderValue from '@patternfly/react-tokens/dist/esm/c_slider_value';
 import cssFormControlWidthChars from '@patternfly/react-tokens/dist/esm/c_slider__value_c_form_control_width_chars';
-import { formatLocalizedDecimal, getLanguageDirection, parseLocalizedDecimal } from '../../helpers/util';
+import {
+  formatLocalizedDecimal,
+  getLanguageDirection,
+  getLocalizedInputWidthChars,
+  parseLocalizedDecimal
+} from '../../helpers/util';
 
 /** Properties for creating custom steps in a slider. These properties should be passed in as
  * an object within an array to the slider component's customSteps property.
@@ -134,12 +139,17 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   const sliderRailRef = useRef<HTMLDivElement>(undefined);
   const thumbRef = useRef<HTMLDivElement>(undefined);
   const isInputFocusedRef = useRef(false);
-  let formatter: Intl.NumberFormat;
-  try {
-    formatter = new Intl.NumberFormat(locale);
-  } catch {
-    formatter = new Intl.NumberFormat(); // grabs default locale
-  }
+  const formatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat(locale, { useGrouping: false });
+    } catch (error) {
+      if (error instanceof RangeError) {
+        // this is what happens if a bad locale is passed in
+        return new Intl.NumberFormat(undefined, { useGrouping: false });
+      }
+      throw error;
+    }
+  }, [locale]);
 
   const [localValue, setValue] = useState(value);
   const [localInputValue, setLocalInputValue] = useState(inputValue);
@@ -155,9 +165,12 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     setValue(value);
   }, [value]);
 
-  const updateInputDisplay = useCallback((numericValue: number) => {
-    setInputDisplayValue(formatLocalizedDecimal(numericValue, formatter));
-  }, []);
+  const updateInputDisplay = useCallback(
+    (numericValue: number) => {
+      setInputDisplayValue(formatLocalizedDecimal(numericValue, formatter));
+    },
+    [formatter]
+  );
 
   const updateInputFromSliderValue = useCallback(
     (numericValue: number) => {
@@ -201,8 +214,15 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   // calculate style value percentage
   const stylePercent = ((localValue - min) * 100) / (max - min);
   const style = { [cssSliderValue.name]: `${stylePercent}%` } as React.CSSProperties;
-  const widthChars = useMemo(() => inputDisplayValue.length || 1, [inputDisplayValue]);
-  const inputStyle = { [cssFormControlWidthChars.name]: widthChars } as React.CSSProperties;
+  const inputStyle = useMemo(() => {
+    if (!isInputVisible) {
+      return undefined;
+    }
+
+    const widthChars = getLocalizedInputWidthChars(formatter, min, max, inputDisplayValue);
+
+    return { [cssFormControlWidthChars.name]: widthChars } as React.CSSProperties;
+  }, [isInputVisible, formatter, min, max, inputDisplayValue]);
 
   const onChangeHandler = (event: React.FormEvent<HTMLInputElement>, value: string) => {
     setInputDisplayValue(value);
@@ -312,9 +332,10 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     if (snapValue && !areCustomStepsContinuous) {
       thumbRef.current.style.setProperty(cssSliderValue.name, `${snapValue}%`);
       setValue(snapValue);
-      updateInputFromSliderValue(snapValue);
       if (onChange) {
         onChange(e, snapValue, undefined, setLocalInputValueWithDisplay);
+      } else {
+        updateInputFromSliderValue(snapValue);
       }
     }
   };
@@ -382,10 +403,11 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
 
     // Call onchange callback
     const resolvedValue = snapValue !== undefined ? snapValue : newValue;
-    updateInputFromSliderValue(resolvedValue);
 
     if (onChange) {
       onChange(e, resolvedValue, undefined, setLocalInputValueWithDisplay);
+    } else {
+      updateInputFromSliderValue(resolvedValue);
     }
   };
 
@@ -452,9 +474,10 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     if (newValue !== localValue) {
       thumbRef.current.style.setProperty(cssSliderValue.name, `${newValue}%`);
       setValue(newValue);
-      updateInputFromSliderValue(newValue);
       if (onChange) {
         onChange(e, newValue, undefined, setLocalInputValueWithDisplay);
+      } else {
+        updateInputFromSliderValue(newValue);
       }
     }
   };

--- a/packages/react-core/src/components/Slider/__tests__/Slider.test.tsx
+++ b/packages/react-core/src/components/Slider/__tests__/Slider.test.tsx
@@ -124,3 +124,24 @@ test('renders slider with thumbAriaValueText', () => {
 
   expect(slider).toHaveAttribute('aria-valuetext', 'Half capacity');
 });
+
+test('displays localized decimal separator based on language', () => {
+  render(<Slider value={50.2} isInputVisible inputValue={50.2} locale="de-DE" />);
+
+  expect(screen.getByRole('textbox', { name: 'Slider value input' })).toHaveValue('50,2');
+});
+
+test('accepts comma decimal input and normalizes on blur', async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+
+  render(<Slider value={50} isInputVisible inputValue={50} locale="de-DE" onChange={onChange} />);
+
+  const input = screen.getByRole('textbox', { name: 'Slider value input' });
+  await user.clear(input);
+  await user.type(input, '62,5');
+  await user.tab();
+
+  expect(input).toHaveValue('62,5');
+  expect(onChange).toHaveBeenLastCalledWith(expect.any(Object), 50, 62.5, expect.any(Function));
+});

--- a/packages/react-core/src/components/Slider/__tests__/Slider.test.tsx
+++ b/packages/react-core/src/components/Slider/__tests__/Slider.test.tsx
@@ -145,3 +145,9 @@ test('accepts comma decimal input and normalizes on blur', async () => {
   expect(input).toHaveValue('62,5');
   expect(onChange).toHaveBeenLastCalledWith(expect.any(Object), 50, 62.5, expect.any(Function));
 });
+
+test('renders with invalid locale using default number formatting', () => {
+  render(<Slider value={50.2} isInputVisible inputValue={50.2} locale="invalid-locale-tag" />);
+
+  expect(screen.getByRole('textbox', { name: 'Slider value input' })).toHaveValue('50.2');
+});

--- a/packages/react-core/src/components/Slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -65,7 +65,8 @@ exports[`slider renders continuous slider 1`] = `
           data-ouia-component-id="OUIA-Generated-TextInputBase-:r1:"
           data-ouia-component-type="PF6/TextInput"
           data-ouia-safe="true"
-          type="number"
+          inputmode="decimal"
+          type="text"
           value="50"
         />
       </span>
@@ -259,7 +260,8 @@ exports[`slider renders discrete slider 1`] = `
           data-ouia-component-id="OUIA-Generated-TextInputBase-:r3:"
           data-ouia-component-type="PF6/TextInput"
           data-ouia-safe="true"
-          type="number"
+          inputmode="decimal"
+          type="text"
           value="50"
         />
       </span>
@@ -431,7 +433,8 @@ exports[`slider renders slider with input 1`] = `
               data-ouia-component-id="OUIA-Generated-TextInputBase-:r5:"
               data-ouia-component-type="PF6/TextInput"
               data-ouia-safe="true"
-              type="number"
+              inputmode="decimal"
+              type="text"
               value="50"
             />
           </span>
@@ -521,7 +524,8 @@ exports[`slider renders slider with input above thumb 1`] = `
                 data-ouia-component-id="OUIA-Generated-TextInputBase-:r7:"
                 data-ouia-component-type="PF6/TextInput"
                 data-ouia-safe="true"
-                type="number"
+                inputmode="decimal"
+                type="text"
                 value="50"
               />
             </span>

--- a/packages/react-core/src/components/Slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`slider renders continuous slider 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 2;"
+    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 3;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -79,7 +79,7 @@ exports[`slider renders continuous slider with custom steps 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 1;"
+    style="--pf-v6-c-slider--value: 50%;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -142,7 +142,7 @@ exports[`slider renders disabled slider 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider pf-m-disabled"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 1;"
+    style="--pf-v6-c-slider--value: 50%;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -199,7 +199,7 @@ exports[`slider renders discrete slider 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 40%; --pf-v6-c-slider__value--c-form-control--width-chars: 2;"
+    style="--pf-v6-c-slider--value: 40%; --pf-v6-c-slider__value--c-form-control--width-chars: 3;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -274,7 +274,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 1;"
+    style="--pf-v6-c-slider--value: 50%;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -366,7 +366,7 @@ exports[`slider renders slider with input 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 2;"
+    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 3;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -458,7 +458,7 @@ exports[`slider renders slider with input above thumb 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 2;"
+    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 3;"
   >
     <div
       class="pf-v6-c-slider__main"
@@ -550,7 +550,7 @@ exports[`slider renders slider with input actions 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 1;"
+    style="--pf-v6-c-slider--value: 50%;"
   >
     <div
       class="pf-v6-c-slider__actions"
@@ -631,7 +631,7 @@ exports[`slider renders slider with tooltip on thumb 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-slider"
-    style="--pf-v6-c-slider--value: 50%; --pf-v6-c-slider__value--c-form-control--width-chars: 1;"
+    style="--pf-v6-c-slider--value: 50%;"
   >
     <div
       class="pf-v6-c-slider__main"

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -32,6 +32,14 @@ import RhUiUnlockFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-unl
 
 ```
 
+### With localized input
+
+To format and parse decimal values using locale-specific separators, use the `locale` prop with a BCP 47 language tag. For example, German (`de-DE`) and Spanish (`es-ES`) use a comma, while English (`en-US`) uses a period.
+
+```ts file="./SliderValueLocalizedInput.tsx"
+
+```
+
 ### Thumb value input
 
 ```ts file="./SliderThumbValueInput.tsx"

--- a/packages/react-core/src/components/Slider/examples/SliderValueLocalizedInput.tsx
+++ b/packages/react-core/src/components/Slider/examples/SliderValueLocalizedInput.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Content, Slider, SliderOnChangeEvent } from '@patternfly/react-core';
+
+const boundarySteps = [
+  { value: 0, label: '0' },
+  { value: 1, label: '1' }
+];
+
+export const SliderValueLocalizedInput: React.FunctionComponent = () => {
+  const [valueDe, setValueDe] = useState(0.6);
+  const [inputValueDe, setInputValueDe] = useState(0.6);
+  const [valueEn, setValueEn] = useState(0.5);
+  const [inputValueEn, setInputValueEn] = useState(0.5);
+
+  const onChangeDe = (
+    _event: SliderOnChangeEvent,
+    value: number,
+    inputValue: number,
+    setLocalInputValue: React.Dispatch<React.SetStateAction<number>>
+  ) => {
+    if (inputValue === undefined) {
+      setValueDe(value);
+      setInputValueDe(value);
+    } else {
+      const newValue = Math.min(1, Math.max(0, inputValue));
+      if (newValue !== inputValue) {
+        setLocalInputValue(newValue);
+      }
+      setValueDe(newValue);
+      setInputValueDe(newValue);
+    }
+  };
+
+  const onChangeEn = (
+    _event: SliderOnChangeEvent,
+    value: number,
+    inputValue: number,
+    setLocalInputValue: React.Dispatch<React.SetStateAction<number>>
+  ) => {
+    if (inputValue === undefined) {
+      setValueEn(value);
+      setInputValueEn(value);
+    } else {
+      const newValue = Math.min(1, Math.max(0, inputValue));
+      if (newValue !== inputValue) {
+        setLocalInputValue(newValue);
+      }
+      setValueEn(newValue);
+      setInputValueEn(newValue);
+    }
+  };
+
+  return (
+    <>
+      <Content component="small">German locale (de-DE) - uses a comma as the decimal separator</Content>
+      <Slider
+        value={valueDe}
+        min={0}
+        max={1}
+        step={0.1}
+        isInputVisible
+        inputValue={inputValueDe}
+        areCustomStepsContinuous
+        customSteps={boundarySteps}
+        locale="de-DE"
+        onChange={onChangeDe}
+      />
+      <br />
+      <Content component="small">English locale (en-US) - uses a period as the decimal separator</Content>
+      <Slider
+        value={valueEn}
+        min={0}
+        max={1}
+        step={0.1}
+        isInputVisible
+        inputValue={inputValueEn}
+        areCustomStepsContinuous
+        customSteps={boundarySteps}
+        locale="en-US"
+        onChange={onChangeEn}
+      />
+    </>
+  );
+};

--- a/packages/react-core/src/helpers/__tests__/util.test.ts
+++ b/packages/react-core/src/helpers/__tests__/util.test.ts
@@ -1,12 +1,15 @@
 import {
   capitalize,
+  formatLocalizedDecimal,
+  formatBreakpointMods,
+  getElementLocale,
   getUniqueId,
   debounce,
   isElementInView,
+  parseLocalizedDecimal,
   sideElementIsOutOfView,
   fillTemplate,
-  pluralize,
-  formatBreakpointMods
+  pluralize
 } from '../util';
 import { SIDE } from '../constants';
 import styles from '@patternfly/react-styles/css/layouts/Flex/flex';
@@ -109,4 +112,20 @@ test('formatBreakpointMods', () => {
   expect(formatBreakpointMods({ default: 'spacerNone' }, styles)).toEqual('pf-m-spacer-none');
   expect(formatBreakpointMods({ md: 'spacerNone' }, styles)).toEqual('pf-m-spacer-none-on-md');
   expect(formatBreakpointMods({ default: 'column', lg: 'row' }, styles)).toEqual('pf-m-column pf-m-row-on-lg');
+});
+
+test('parseLocalizedDecimal accepts dot and comma decimal separators', () => {
+  const enFormatter = new Intl.NumberFormat('en');
+  const esFormatter = new Intl.NumberFormat('es');
+
+  expect(parseLocalizedDecimal('50.2', enFormatter)).toBe(50.2);
+  expect(parseLocalizedDecimal('50,2', esFormatter)).toBe(50.2);
+  expect(parseLocalizedDecimal('1.234,56', esFormatter)).toBe(1234.56);
+  expect(parseLocalizedDecimal('1,234.56', enFormatter)).toBe(1234.56);
+  expect(parseLocalizedDecimal('', enFormatter)).toBeNaN();
+});
+
+test('formatLocalizedDecimal uses locale decimal separator', () => {
+  expect(formatLocalizedDecimal(50.2, new Intl.NumberFormat('en-US'))).toBe('50.2');
+  expect(formatLocalizedDecimal(50.2, new Intl.NumberFormat('de-DE'))).toBe('50,2');
 });

--- a/packages/react-core/src/helpers/__tests__/util.test.ts
+++ b/packages/react-core/src/helpers/__tests__/util.test.ts
@@ -3,6 +3,7 @@ import {
   formatLocalizedDecimal,
   formatBreakpointMods,
   getElementLocale,
+  getLocalizedInputWidthChars,
   getUniqueId,
   debounce,
   isElementInView,
@@ -114,18 +115,62 @@ test('formatBreakpointMods', () => {
   expect(formatBreakpointMods({ default: 'column', lg: 'row' }, styles)).toEqual('pf-m-column pf-m-row-on-lg');
 });
 
-test('parseLocalizedDecimal accepts dot and comma decimal separators', () => {
-  const enFormatter = new Intl.NumberFormat('en');
-  const esFormatter = new Intl.NumberFormat('es');
+test('parseLocalizedDecimal accepts locale-formatted decimals', () => {
+  const enFormatter = new Intl.NumberFormat('en', { useGrouping: false });
+  const esFormatter = new Intl.NumberFormat('es', { useGrouping: false });
+  const deFormatter = new Intl.NumberFormat('de-DE', { useGrouping: false });
 
   expect(parseLocalizedDecimal('50.2', enFormatter)).toBe(50.2);
   expect(parseLocalizedDecimal('50,2', esFormatter)).toBe(50.2);
-  expect(parseLocalizedDecimal('1.234,56', esFormatter)).toBe(1234.56);
-  expect(parseLocalizedDecimal('1,234.56', enFormatter)).toBe(1234.56);
+  expect(parseLocalizedDecimal('0,625', deFormatter)).toBe(0.625);
   expect(parseLocalizedDecimal('', enFormatter)).toBeNaN();
+});
+
+test('parseLocalizedDecimal rejects mismatched separators', () => {
+  const enFormatter = new Intl.NumberFormat('en-US', { useGrouping: false });
+  const deFormatter = new Intl.NumberFormat('de-DE', { useGrouping: false });
+
+  expect(parseLocalizedDecimal('50,2', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('50.2', deFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('50,2', deFormatter)).toBe(50.2);
+});
+
+test('parseLocalizedDecimal rejects grouping separators', () => {
+  const enFormatter = new Intl.NumberFormat('en-US');
+  const esFormatter = new Intl.NumberFormat('es');
+  const deFormatter = new Intl.NumberFormat('de-DE');
+  const enINFormatter = new Intl.NumberFormat('en-IN');
+
+  expect(parseLocalizedDecimal('1,234.56', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('12.345,67', esFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('1.234,56', deFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('12,34,567', enINFormatter)).toBeNaN();
+});
+
+test('parseLocalizedDecimal rejects malformed numeric tokens', () => {
+  const enFormatter = new Intl.NumberFormat('en-US');
+
+  expect(parseLocalizedDecimal('12abc', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('1,2abc', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('12-3', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('--12', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('+-12', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('12.3.4', enFormatter)).toBeNaN();
+  expect(parseLocalizedDecimal('abc', enFormatter)).toBeNaN();
+
+  expect(parseLocalizedDecimal('-50.2', enFormatter)).toBe(-50.2);
+  expect(parseLocalizedDecimal('+12', enFormatter)).toBe(12);
+  expect(parseLocalizedDecimal('1,234.56', enFormatter)).toBeNaN();
 });
 
 test('formatLocalizedDecimal uses locale decimal separator', () => {
   expect(formatLocalizedDecimal(50.2, new Intl.NumberFormat('en-US'))).toBe('50.2');
   expect(formatLocalizedDecimal(50.2, new Intl.NumberFormat('de-DE'))).toBe('50,2');
+});
+
+test('getLocalizedInputWidthChars stays wide enough for shorter formatted values', () => {
+  const formatter = new Intl.NumberFormat('de-DE', { useGrouping: false });
+
+  expect(getLocalizedInputWidthChars(formatter, 0, 1, '1')).toBe(formatLocalizedDecimal(0.99, formatter).length);
+  expect(getLocalizedInputWidthChars(formatter, 0, 100, '5')).toBe(formatLocalizedDecimal(100, formatter).length);
 });

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -592,8 +592,9 @@ export const getInlineStartProperty = (
 };
 
 /**
- * Parses a decimal input string, accepting both comma and dot as the decimal separator.
- * Given the locale, it discovers the locale's separators and integers using a reference value.
+ * Parses a decimal input string using the given formatter's locale decimal separator.
+ * Grouping separators are not supported; use a formatter with `useGrouping: false`
+ * to avoid ambiguity between group and decimal separators in some locales.
  *
  * @param {string} value - The input string to parse
  * @param {Intl.NumberFormat} formatter - The Intl.NumberFormat instance to use for formatting
@@ -605,31 +606,48 @@ export const parseLocalizedDecimal = (value: string, formatter: Intl.NumberForma
   }
 
   const parts = formatter.formatToParts(12345.6);
-  const groupSymbol = parts.find((p) => p.type === 'group')?.value || ',';
-  const decimalSymbol = parts.find((p) => p.type === 'decimal')?.value || '.';
+  const groupSymbol = parts.find((p) => p.type === 'group')?.value;
+  const decimalPart = parts.find((p) => p.type === 'decimal');
+  const decimalSymbol = decimalPart?.value ?? '.';
+  const normalizedString = value.trim();
 
-  // in case of non-Arabic numerals
-  const digitParts = formatter.formatToParts(1234567890);
-  const localDigits = digitParts
-    .filter((p) => p.type === 'integer')
-    .map((p) => p.value)
-    .join('');
-  let normalizedString = value;
-  if (localDigits.length === 10 && localDigits !== '1234567890') {
-    const standardDigits = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'];
-    const digitMap = new Map();
-    [...localDigits].forEach((char, idx) => digitMap.set(char, standardDigits[idx]));
-    normalizedString = [...value].map((char) => digitMap.get(char) || char).join('');
+  if (groupSymbol && normalizedString.includes(groupSymbol)) {
+    return NaN;
   }
 
-  const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const decimalIndex = normalizedString.indexOf(decimalSymbol);
+  const hasDecimalSeparator = decimalIndex !== -1;
 
-  const cleaned = normalizedString
-    .replace(new RegExp(escapeRegex(groupSymbol), 'g'), '')
-    .replace(new RegExp(escapeRegex(decimalSymbol), 'g'), '.')
-    .replace(/[^0-9.-]/g, '');
+  if (hasDecimalSeparator && normalizedString.indexOf(decimalSymbol, decimalIndex + decimalSymbol.length) !== -1) {
+    return NaN;
+  }
 
-  return parseFloat(cleaned);
+  const charsWithoutDecimal = hasDecimalSeparator
+    ? normalizedString.slice(0, decimalIndex) + normalizedString.slice(decimalIndex + decimalSymbol.length)
+    : normalizedString;
+
+  if (!/^[+-]?\d*$/.test(charsWithoutDecimal)) {
+    return NaN;
+  }
+
+  let intPart = hasDecimalSeparator ? normalizedString.slice(0, decimalIndex) : normalizedString;
+  const fracPart = hasDecimalSeparator ? normalizedString.slice(decimalIndex + decimalSymbol.length) : undefined;
+
+  let sign = '';
+  if (intPart.startsWith('-') || intPart.startsWith('+')) {
+    sign = intPart[0] === '-' ? '-' : '';
+    intPart = intPart.slice(1);
+  }
+
+  if (!/^\d*$/.test(intPart) || (fracPart !== undefined && !/^\d*$/.test(fracPart))) {
+    return NaN;
+  }
+
+  if (intPart === '' && (fracPart === undefined || fracPart === '')) {
+    return NaN;
+  }
+
+  return parseFloat(`${sign}${intPart || '0'}${fracPart !== undefined ? `.${fracPart}` : ''}`);
 };
 
 /**
@@ -645,4 +663,35 @@ export const formatLocalizedDecimal = (value: number, formatter: Intl.NumberForm
   }
 
   return formatter.format(value);
+};
+
+/**
+ * Returns a stable character width for a localized slider input based on its range, so the
+ * input doesn't resize as its value changes (e.g. going from "0.99" to "1").
+ *
+ * Checks the formatted length of three values: the min, the max, and a value 1% below the
+ * max (to account for decimals that may be longer than the max itself, e.g. a 0-1 range).
+ * Never shrinks below the currently displayed value, so the input can grow while typing.
+ *
+ * @param {Intl.NumberFormat} formatter - Intl.NumberFormat instance to use for formatting
+ * @param {number} min - The minimum value
+ * @param {number} max - The maximum value
+ * @param {number} inputDisplayValue - The value shown in the input field
+ * @returns {number} - The character width for the slider input
+ */
+export const getLocalizedInputWidthChars = (
+  formatter: Intl.NumberFormat,
+  min: number,
+  max: number,
+  inputDisplayValue: string
+): number => {
+  const nearMax = max > min ? max - (max - min) / 100 : max;
+
+  const widestBoundaryLength = Math.max(
+    formatLocalizedDecimal(min, formatter).length,
+    formatLocalizedDecimal(max, formatter).length,
+    formatLocalizedDecimal(nearMax, formatter).length
+  );
+
+  return Math.max(widestBoundaryLength, inputDisplayValue.length, 1);
 };

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -590,3 +590,59 @@ export const getInlineStartProperty = (
   const widthProperty: 'offsetWidth' | 'clientWidth' | 'scrollWidth' = `${inlineType}Width`;
   return ancestorElement[widthProperty] - (targetElement[inlineProperty] + targetElement[widthProperty]);
 };
+
+/**
+ * Parses a decimal input string, accepting both comma and dot as the decimal separator.
+ * Given the locale, it discovers the locale's separators and integers using a reference value.
+ *
+ * @param {string} value - The input string to parse
+ * @param {Intl.NumberFormat} formatter - The Intl.NumberFormat instance to use for formatting
+ * @returns {number} - The parsed number, or NaN if the input is not a valid number
+ */
+export const parseLocalizedDecimal = (value: string, formatter: Intl.NumberFormat): number => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return NaN;
+  }
+
+  const parts = formatter.formatToParts(12345.6);
+  const groupSymbol = parts.find((p) => p.type === 'group')?.value || ',';
+  const decimalSymbol = parts.find((p) => p.type === 'decimal')?.value || '.';
+
+  // in case of non-Arabic numerals
+  const digitParts = formatter.formatToParts(1234567890);
+  const localDigits = digitParts
+    .filter((p) => p.type === 'integer')
+    .map((p) => p.value)
+    .join('');
+  let normalizedString = value;
+  if (localDigits.length === 10 && localDigits !== '1234567890') {
+    const standardDigits = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'];
+    const digitMap = new Map();
+    [...localDigits].forEach((char, idx) => digitMap.set(char, standardDigits[idx]));
+    normalizedString = [...value].map((char) => digitMap.get(char) || char).join('');
+  }
+
+  const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const cleaned = normalizedString
+    .replace(new RegExp(escapeRegex(groupSymbol), 'g'), '')
+    .replace(new RegExp(escapeRegex(decimalSymbol), 'g'), '.')
+    .replace(/[^0-9.-]/g, '');
+
+  return parseFloat(cleaned);
+};
+
+/**
+ * Formats a number using the decimal separator for the given locale.
+ *
+ * @param {number} value - The number to format
+ * @param {Intl.NumberFormat} formatter - Intl.NumberFormat instance to use for formatting
+ * @returns {string} - The formatted number string
+ */
+export const formatLocalizedDecimal = (value: number, formatter: Intl.NumberFormat): string => {
+  if (Number.isNaN(value)) {
+    return '';
+  }
+
+  return formatter.format(value);
+};

--- a/packages/react-integration/cypress/integration/slider.spec.ts
+++ b/packages/react-integration/cypress/integration/slider.spec.ts
@@ -7,20 +7,14 @@ describe('Slider Demo Test', () => {
     cy.get('#discrete-slider').should('exist');
     cy.get('#discrete-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*62\.5%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*62\.5%\s*;?/);
     cy.get('#discrete-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb')
       .trigger('mousedown', { which: 1 })
       .trigger('mousemove', 150, 10, { force: true })
       .trigger('mouseup', { force: true });
     cy.get('#discrete-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*75%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*75%\s*;?/);
   });
 
   xit('changes discrete slider value using keyboard', () => {
@@ -30,10 +24,7 @@ describe('Slider Demo Test', () => {
     cy.get('#discrete-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb').trigger('keyup', { keyCode: 39 });
     cy.get('#discrete-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*87\.5%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*87\.5%\s*;?/);
   });
 
   it('changes continuous slider value when dragged', () => {
@@ -42,7 +33,7 @@ describe('Slider Demo Test', () => {
       .invoke('attr', 'style')
       .should(
         'match',
-        /--pf-v6-c-slider--value:\s*50%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*2\s*;/
+        /--pf-v6-c-slider--value:\s*50%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*3\s*;/
       );
     cy.get('#continuous-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb')
       .trigger('mousedown', { which: 1 })
@@ -75,10 +66,7 @@ describe('Slider Demo Test', () => {
     cy.get('#disabled-slider').should('exist');
     cy.get('#disabled-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*20%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*20%\s*;?/);
 
     cy.get('#disabled-slider').should('have.class', 'pf-m-disabled');
     cy.get('#disabled-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb')
@@ -87,10 +75,7 @@ describe('Slider Demo Test', () => {
       .trigger('mouseup', { force: true });
     cy.get('#disabled-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*20%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*20%\s*;?/);
   });
 
   it('changes custom steps slider value when dragged', () => {
@@ -98,29 +83,20 @@ describe('Slider Demo Test', () => {
 
     cy.get('#custom-steps-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*20%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*20%\s*;?/);
     cy.get('#custom-steps-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb')
       .trigger('mousedown', { which: 1 })
       .trigger('mousemove', -200, 10, { force: true })
       .trigger('mouseup', { force: true });
     cy.get('#custom-steps-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*0%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*0%\s*;?/);
   });
 
   it('changes custom steps slider value using keyboard', () => {
     cy.get('#custom-steps-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*0%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*0%\s*;?/);
 
     cy.get('#custom-steps-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb').focus();
     cy.get('#custom-steps-slider > .pf-v6-c-slider__main > .pf-v6-c-slider__thumb').trigger('keydown', { keyCode: 39 });
@@ -129,9 +105,6 @@ describe('Slider Demo Test', () => {
 
     cy.get('#custom-steps-slider')
       .invoke('attr', 'style')
-      .should(
-        'match',
-        /--pf-v6-c-slider--value:\s*20%\s*;?\s*--pf-v6-c-slider__value--c-form-control--width-chars:\s*1\s*;/
-      );
+      .should('match', /--pf-v6-c-slider--value:\s*20%\s*;?/);
   });
 });

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -4,6 +4,7 @@
     "jsx": "react-jsx",
     "lib": [
       "es2015",
+      "es2018.intl",
       "dom"
     ],
     "target": "es2015",


### PR DESCRIPTION
I went with a locale prop since it seemed like it would provide a better, more consistent solution. There are a lot of ways people could be setting language. Examples: https://github.com/i18next/i18next-browser-languageDetector#introduction.

OpenShift (the internationalized system I'm most familiar with) doesn't update the lang attribute when it changes languages, so I didn't want to rely on that.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/12052

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `locale` option to `Slider` for locale-aware decimal formatting/parsing in the optional value input.
  * Added a localized-input example demonstrating different locales and value entry behavior.
* **Bug Fixes**
  * Improved synchronization between the slider and text input to avoid overwriting in-progress edits and to normalize/commit values on Enter/blur.
* **Tests**
  * Added tests for localized decimal formatting/parsing, validation of decimal/grouping separators, and slider input commit behavior.
  * Expanded helper utility test coverage for localized input width calculations.
* **Documentation**
  * Updated typings to include `es2018.intl`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->