### PR TITLE
fix(helpers): keep falsy but defined values in fillTemplate

### DIFF
--- a/packages/react-core/src/helpers/__tests__/util.test.ts
+++ b/packages/react-core/src/helpers/__tests__/util.test.ts
@@ -99,6 +99,16 @@ test('fillTemplate interpolates strings correctly', () => {
   expect(actual).toEqual(expected);
 });
 
+test('fillTemplate keeps falsy but defined values such as 0 and false', () => {
+  expect(fillTemplate('count: ${n}', { n: 0 })).toEqual('count: 0');
+  expect(fillTemplate('value: ${v}', { v: false })).toEqual('value: false');
+  expect(fillTemplate('empty:${e}!', { e: '' })).toEqual('empty:!');
+});
+
+test('fillTemplate replaces missing keys with an empty string', () => {
+  expect(fillTemplate('x=${missing}', {})).toEqual('x=');
+});
+
 test('text pluralize', () => {
   expect(pluralize(1, 'dog')).toEqual('1 dog');
   expect(pluralize(2, 'dog')).toEqual('2 dogs');

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -114,7 +114,7 @@ export function sideElementIsOutOfView(container: HTMLElement, element: HTMLElem
  * @returns {string} The template string literal result
  */
 export function fillTemplate(templateString: string, templateVars: any) {
-  return templateString.replace(/\${(.*?)}/g, (_, match) => templateVars[match] || '');
+  return templateString.replace(/\${(.*?)}/g, (_, match) => templateVars[match] ?? '');
 }
 
 /**


### PR DESCRIPTION
**What**: Fixes a bug in the `fillTemplate` helper (`packages/react-core/src/helpers/util.ts`).

`fillTemplate` replaced each `${var}` with `templateVars[match] || ''`, which also dropped values that are defined but falsy, such as the number `0` or the boolean `false`. For example:

```js
fillTemplate('${n}', { n: 0 });    // returned '' instead of '0'
fillTemplate('${v}', { v: false }); // returned '' instead of 'false'
```

This shows up in Pagination. `PaginationOptionsMenu` passes numeric `firstIndex`, `lastIndex` and `itemCount` into a string toggle template, so an empty data set (`itemCount` of `0`) silently dropped the `0` from the rendered toggle text (for example `1 - 0 of ` instead of `1 - 0 of 0`).

The fix switches `||` to the nullish coalescing operator `??`, so only `null` or `undefined` (for example a missing key) fall back to an empty string, while `0` and `false` are preserved. Missing keys still resolve to an empty string, so existing behavior is unchanged.

**Additional issues**: none. This was found while reading the helper code.

**Testing**: added unit tests in `util.test.ts` covering `0`, `false`, empty string, and missing keys. The existing `fillTemplate` interpolation test still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Template filling now correctly preserves valid falsy values such as `0`, `false`, and empty strings.
  - Missing or null template values continue to be replaced with empty strings.

- **Tests**
  - Added coverage for falsy and missing template values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->