### PR TITLE
chore: fix editable table alignent

### DIFF
--- a/packages/react-table/src/components/Table/examples/TableEditable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableEditable.tsx
@@ -35,48 +35,46 @@ const EditButtonsCell: React.FunctionComponent<EditButtonsCellProps> = ({
 
   return (
     <>
-      <Td
-        dataLabel="Save and cancel buttons"
-        className={css(
-          inlineEditStyles.inlineEditGroup,
-          inlineEditStyles.modifiers.iconGroup,
-          inlineEditStyles.modifiers.actionGroup
-        )}
-      >
-        <div className={css(inlineEditStyles.inlineEditAction, inlineEditStyles.modifiers.valid)}>
-          <Button
-            aria-label={`Save edits of ${rowAriaLabel}`}
-            onClick={() => onClick('save')}
-            onKeyDown={(event) => onKeyDown(event, 'stopEditing')}
-            variant="plain"
-          >
-            <RhMicronsCheckmarkIcon />
-          </Button>
-        </div>
-        <div className={css(inlineEditStyles.inlineEditAction)}>
-          <Button
-            aria-label={`Discard edits of ${rowAriaLabel}`}
-            onClick={() => onClick('cancel')}
-            onKeyDown={(event) => onKeyDown(event, 'stopEditing')}
-            variant="plain"
-          >
-            <RhMicronsCloseIcon />
-          </Button>
-        </div>
-      </Td>
-      <Td
-        dataLabel="Edit button"
-        className={css(inlineEditStyles.inlineEditAction, inlineEditStyles.modifiers.enableEditable)}
-      >
-        <Button
-          ref={editButtonRef}
-          aria-label={`Edit ${rowAriaLabel}`}
-          onClick={() => onClick('edit')}
-          onKeyDown={(event) => onKeyDown(event, 'edit')}
-          variant="plain"
+      <Td dataLabel="Edit row data" hasAction>
+        <div
+          className={css(
+            inlineEditStyles.inlineEditGroup,
+            inlineEditStyles.modifiers.iconGroup,
+            inlineEditStyles.modifiers.actionGroup
+          )}
         >
-          <RhUiEditFillIcon />
-        </Button>
+          <div className={css(inlineEditStyles.inlineEditAction, inlineEditStyles.modifiers.valid)}>
+            <Button
+              aria-label={`Save edits of ${rowAriaLabel}`}
+              onClick={() => onClick('save')}
+              onKeyDown={(event) => onKeyDown(event, 'stopEditing')}
+              variant="plain"
+            >
+              <RhMicronsCheckmarkIcon />
+            </Button>
+          </div>
+          <div className={css(inlineEditStyles.inlineEditAction)}>
+            <Button
+              aria-label={`Discard edits of ${rowAriaLabel}`}
+              onClick={() => onClick('cancel')}
+              onKeyDown={(event) => onKeyDown(event, 'stopEditing')}
+              variant="plain"
+            >
+              <RhMicronsCloseIcon />
+            </Button>
+          </div>
+        </div>
+        <span className={css(inlineEditStyles.inlineEditAction, inlineEditStyles.modifiers.enableEditable)}>
+          <Button
+            ref={editButtonRef}
+            aria-label={`Edit ${rowAriaLabel}`}
+            onClick={() => onClick('edit')}
+            onKeyDown={(event) => onKeyDown(event, 'edit')}
+            variant="plain"
+          >
+            <RhUiEditFillIcon />
+          </Button>
+        </span>
       </Td>
     </>
   );

--- a/packages/react-table/src/components/Table/examples/TableEditable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableEditable.tsx
@@ -64,7 +64,7 @@ const EditButtonsCell: React.FunctionComponent<EditButtonsCellProps> = ({
             </Button>
           </div>
         </div>
-        <span className={css(inlineEditStyles.inlineEditAction, inlineEditStyles.modifiers.enableEditable)}>
+        <div className={css(inlineEditStyles.inlineEditAction, inlineEditStyles.modifiers.enableEditable)}>
           <Button
             ref={editButtonRef}
             aria-label={`Edit ${rowAriaLabel}`}
@@ -74,7 +74,7 @@ const EditButtonsCell: React.FunctionComponent<EditButtonsCellProps> = ({
           >
             <RhUiEditFillIcon />
           </Button>
-        </span>
+        </div>
       </Td>
     </>
   );


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/12618

What this does:
* This just takes the inline editable classes that control showing/hiding things off the `Td` and them to divs that wrap the edit and save/cancel buttons
* Puts everything in a single `Td` instead of 2 - needed after ^ because now the cells don't show/hide dynamically
* Adds `hasAction` to the edit cell so the buttons don't cause the row to be misaligned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Grouped table edit controls within a single cell for a cleaner, more consistent layout.
  * Organized save, discard, and edit actions into distinct inline controls without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->