### PR TITLE
fix(DrawerCloseButton): Allow props spread to button

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerCloseButton.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerCloseButton.tsx
@@ -1,6 +1,6 @@
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
 import { css } from '@patternfly/react-styles';
-import { Button } from '../Button';
+import { Button, ButtonProps } from '../Button';
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 
 export interface DrawerCloseButtonProps extends React.HTMLProps<HTMLDivElement> {
@@ -10,16 +10,30 @@ export interface DrawerCloseButtonProps extends React.HTMLProps<HTMLDivElement> 
   onClose?: () => void;
   /** Accessible label for the drawer close button */
   'aria-label'?: string;
+  /** Additional properties spread to the close button */
+  buttonProps?: Omit<ButtonProps, 'onClick'>;
 }
 
 export const DrawerCloseButton: React.FunctionComponent<DrawerCloseButtonProps> = ({
   className = '',
   onClose = () => undefined as any,
   'aria-label': ariaLabel = 'Close drawer panel',
+  buttonProps,
   ...props
-}: DrawerCloseButtonProps) => (
-  <div className={css(styles.drawerClose, className)} {...props}>
-    <Button variant="plain" onClick={onClose} aria-label={ariaLabel} icon={<RhMicronsCloseIcon />} />
-  </div>
-);
+}: DrawerCloseButtonProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { onClick: _onClick, ...restButtonProps } = (buttonProps ?? {}) as ButtonProps;
+
+  return (
+    <div className={css(styles.drawerClose, className)} {...props}>
+      <Button
+        variant="plain"
+        onClick={onClose}
+        aria-label={ariaLabel}
+        icon={<RhMicronsCloseIcon />}
+        {...restButtonProps}
+      />
+    </div>
+  );
+};
 DrawerCloseButton.displayName = 'DrawerCloseButton';

--- a/packages/react-core/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
+++ b/packages/react-core/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
@@ -5,7 +5,7 @@ import { DrawerCloseButton } from '../DrawerCloseButton';
 
 test('Renders with spread buttonProps', () => {
   render(<DrawerCloseButton buttonProps={{ isDisabled: true }} />);
-  expect(screen.getByRole('button')).toHaveAttribute('disabled');
+  expect(screen.getByRole('button')).toBeDisabled();
 });
 
 test('Calls onClose when clicked', async () => {

--- a/packages/react-core/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
+++ b/packages/react-core/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ButtonProps } from '../../Button';
+import { DrawerCloseButton } from '../DrawerCloseButton';
+
+test('Renders with spread buttonProps', () => {
+  render(<DrawerCloseButton buttonProps={{ isDisabled: true }} />);
+  expect(screen.getByRole('button')).toHaveAttribute('disabled');
+});
+
+test('Calls onClose when clicked', async () => {
+  const onClose = jest.fn();
+  const user = userEvent.setup();
+
+  render(<DrawerCloseButton onClose={onClose} buttonProps={{ isDisabled: false }} />);
+  await user.click(screen.getByRole('button'));
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test('Does not spread onClick from buttonProps but spreads other props', async () => {
+  const onClose = jest.fn();
+  const buttonOnClick = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <DrawerCloseButton
+      onClose={onClose}
+      buttonProps={{ id: 'drawer-close-button', onClick: buttonOnClick } as ButtonProps}
+    />
+  );
+
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('id', 'drawer-close-button');
+
+  await user.click(button);
+
+  expect(onClose).toHaveBeenCalledTimes(1);
+  expect(buttonOnClick).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Props were previously only spread to parent div. This allows for props spread to button.

Enables https://github.com/patternfly/chatbot/issues/834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the Drawer close button with additional button properties.
  * Close buttons can now be disabled through the provided configuration.
  * Existing close behavior remains protected while other supported button properties are applied.

* **Tests**
  * Added coverage for disabled states, click behavior, custom property forwarding, and preservation of the built-in close action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->