### PR TITLE
docs(deprecated Table): remove old css prefix from md

### DIFF
--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -1,6 +1,5 @@
 ---
 id: Table
-cssPrefix: pf-c-table
 section: components
 propComponents: ['Table', 'TableHeader', 'TableBody', 'ISortBy']
 ouia: true


### PR DESCRIPTION
Removes css prefix from deprecated Table md file. This was creating a separate CSS variables table with no content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated styling metadata from the deprecated Table example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->