### PR TITLE
fix(CI): split documentation workflow to avoid pull_request_target checkout block

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -28,10 +28,29 @@ jobs:
       - name: Resolve PR number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
         run: |
-          PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
-          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
-            PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number')
+          set -euo pipefail
+          PR_COUNT=$(jq 'length // 0' <<< "${WORKFLOW_PRS:-null}")
+          if [ "$PR_COUNT" -eq 1 ]; then
+            PR_NUM=$(jq -r '.[0].number' <<< "$WORKFLOW_PRS")
+          elif [ "$PR_COUNT" -eq 0 ]; then
+            if ! [[ "$HEAD_SHA" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
+              echo "Invalid source workflow head SHA"
+              exit 1
+            fi
+            PR_JSON=$(gh api --paginate "repos/${REPOSITORY}/commits/${HEAD_SHA}/pulls")
+            PR_COUNT=$(jq 'length // 0' <<< "$PR_JSON")
+            if [ "$PR_COUNT" -ne 1 ]; then
+              echo "Failed to uniquely resolve PR number for commit ${HEAD_SHA} (found ${PR_COUNT} pull requests)"
+              exit 1
+            fi
+            PR_NUM=$(jq -r '.[0].number' <<< "$PR_JSON")
+          else
+            echo "Ambiguous PR metadata: found ${PR_COUNT} pull requests on the source workflow run"
+            exit 1
           fi
           if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
             echo "Failed to resolve a valid PR number"
@@ -59,5 +78,5 @@ jobs:
         run: node .github/upload-preview.mjs packages/react-docs/public
 
       - name: Upload accessibility results
-        if: always() && !cancelled()
+        if: ${{ !cancelled() }}
         run: node .github/upload-preview.mjs packages/react-docs/coverage

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -1,0 +1,55 @@
+name: Documentation deploy
+on:
+  workflow_run:
+    workflows: [Documentation]
+    types: [completed]
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
+    env:
+      SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      GH_PR_TOKEN: ${{ secrets.GH_PR_TOKEN }}
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: Set up project
+        uses: ./.github/actions/setup-project
+        with:
+          skip-build: true
+
+      - name: Download PR number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set PR number
+        run: echo "GH_PR_NUM=$(cat pr-number.txt)" >> $GITHUB_ENV
+
+      - name: Download documentation
+        uses: actions/download-artifact@v4
+        with:
+          name: documentation
+          path: packages/react-docs/public
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download a11y coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: a11y-coverage
+          path: packages/react-docs/coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload documentation
+        run: node .github/upload-preview.mjs packages/react-docs/public
+
+      - name: Upload accessibility results
+        if: always()
+        run: node .github/upload-preview.mjs packages/react-docs/coverage

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -3,11 +3,15 @@ on:
   workflow_run:
     workflows: [Documentation]
     types: [completed]
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -21,15 +25,19 @@ jobs:
         with:
           skip-build: true
 
-      - name: Download PR number
-        uses: actions/download-artifact@v4
-        with:
-          name: pr-number
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set PR number
-        run: echo "GH_PR_NUM=$(cat pr-number.txt)" >> $GITHUB_ENV
+      - name: Resolve PR number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
+            PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number')
+          fi
+          if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+            echo "Failed to resolve a valid PR number"
+            exit 1
+          fi
+          echo "GH_PR_NUM=$PR_NUM" >> "$GITHUB_ENV"
 
       - name: Download documentation
         uses: actions/download-artifact@v4
@@ -51,5 +59,5 @@ jobs:
         run: node .github/upload-preview.mjs packages/react-docs/public
 
       - name: Upload accessibility results
-        if: always()
+        if: always() && !cancelled()
         run: node .github/upload-preview.mjs packages/react-docs/coverage

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,6 @@
 name: Documentation
 on:
-  pull_request_target:
+  pull_request:
   issue_comment:
     types: [created]
   workflow_call:
@@ -19,6 +19,7 @@ on:
         required: true
 jobs:
   check-permissions:
+    if: github.event_name == 'issue_comment'
     uses: patternfly/.github/.github/workflows/check-team-membership.yml@fdb52a63a2220ec8a3b6c2d43f312cda708ffa06
     secrets: inherit
 
@@ -29,7 +30,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      (inputs.is-release || needs.check-permissions.outputs.allowed == 'true')
+      (inputs.is-release || github.event_name != 'issue_comment' || needs.check-permissions.outputs.allowed == 'true')
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -37,29 +38,53 @@ jobs:
       GH_PR_NUM: ${{ needs.check-permissions.outputs.pr-number }}
     steps:
       - name: Check out project from PR branch
-        if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
+        if: github.event_name == 'issue_comment'
         uses: actions/checkout@v4
         with:
-          # Checkout the merge commit so that we can access the PR's changes.
-          # This is nessesary because `pull_request_target` checks out the base branch (e.g. `main`) by default.
           ref: refs/pull/${{ env.GH_PR_NUM }}/head
 
       - name: Check out project
-        if: inputs.is-release || github.event_name == 'workflow_call'
+        if: github.event_name != 'issue_comment'
         uses: actions/checkout@v4
+
       - name: Set up and build project
         uses: ./.github/actions/setup-project
 
       - name: Build documentation
         run: yarn build:docs
 
-      - name: Upload documentation
-        if: always()
+      - name: Upload documentation preview
+        if: always() && !cancelled() && github.event_name != 'pull_request'
         run: node .github/upload-preview.mjs packages/react-docs/public
 
       - name: Run accessibility tests
         run: yarn serve:docs & yarn test:a11y
 
       - name: Upload accessibility results
-        if: always()
+        if: always() && !cancelled() && github.event_name != 'pull_request'
         run: node .github/upload-preview.mjs packages/react-docs/coverage
+
+      - name: Upload docs artifact
+        if: always() && !cancelled() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: packages/react-docs/public
+
+      - name: Upload a11y artifact
+        if: always() && !cancelled() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-coverage
+          path: packages/react-docs/coverage
+
+      - name: Save PR number
+        if: always() && !cancelled() && github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR number
+        if: always() && !cancelled() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr-number.txt

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -65,26 +65,15 @@ jobs:
         run: node .github/upload-preview.mjs packages/react-docs/coverage
 
       - name: Upload docs artifact
-        if: always() && !cancelled() && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: packages/react-docs/public
 
       - name: Upload a11y artifact
-        if: always() && !cancelled() && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: a11y-coverage
           path: packages/react-docs/coverage
-
-      - name: Save PR number
-        if: always() && !cancelled() && github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-
-      - name: Upload PR number
-        if: always() && !cancelled() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-number
-          path: pr-number.txt

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,9 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-permissions
     if: >-
-      always() &&
-      !cancelled() &&
-      (inputs.is-release || github.event_name != 'issue_comment' || needs.check-permissions.outputs.allowed == 'true')
+      ${{ !cancelled() &&
+      (inputs.is-release || github.event_name != 'issue_comment' || needs.check-permissions.outputs.allowed == 'true') }}
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -54,14 +53,14 @@ jobs:
         run: yarn build:docs
 
       - name: Upload documentation preview
-        if: always() && !cancelled() && github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         run: node .github/upload-preview.mjs packages/react-docs/public
 
       - name: Run accessibility tests
         run: yarn serve:docs & yarn test:a11y
 
       - name: Upload accessibility results
-        if: always() && !cancelled() && github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         run: node .github/upload-preview.mjs packages/react-docs/coverage
 
       - name: Upload docs artifact


### PR DESCRIPTION
## Summary

- Switches the Documentation workflow from `pull_request_target` to `pull_request` so fork PRs no longer trigger the checkout security block from `actions/checkout@v4`
- For `pull_request` events, builds docs and a11y tests then uploads results as artifacts (no secrets needed)
- Adds a new `documentation-deploy.yml` workflow triggered by `workflow_run` that downloads the artifacts and deploys to Surge using repo secrets
- `issue_comment` and `workflow_call` paths are unchanged — they still build and deploy directly since they have access to secrets
- Preserves the `is-release` `workflow_call` input from #12598 for the Release workflow

Replaces #12621, which was based on `6.6.x` instead of `main`.

Closes #12601

_Test plan for when after this merges to main can be found here https://github.com/patternfly/patternfly-react/issues/12626_


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved documentation preview and deployment workflows.
  * Pull requests now receive documentation and accessibility artifacts without unnecessary preview uploads.
  * Documentation deployments run only after successful workflow completion.
  * Added more reliable pull request identification and validation.
  * Prevented accessibility uploads from running after canceled workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->