### PR TITLE
fix(Modal): updated logic to set aria-hidden for tearsheets

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -117,19 +117,28 @@ class Modal extends Component<ModalProps, ModalState> {
   toggleSiblingsFromScreenReaders = (hide: boolean) => {
     const { appendTo } = this.props;
     const target: HTMLElement = this.getElement(appendTo);
-    const stack = Modal.getStackForTarget(target);
-    const idx = stack.indexOf(this.backdropId);
 
-    if (hide && idx === -1) {
-      stack.push(this.backdropId);
-    } else if (!hide && idx !== -1) {
-      stack.splice(idx, 1);
+    if (hide) {
+      const stack = Modal.getStackForTarget(target);
+      if (stack.indexOf(this.backdropId) === -1) {
+        stack.push(this.backdropId);
+      }
+    } else {
+      const stack = Modal.openModalStacks.get(target);
+      if (!stack) {
+        return;
+      }
+      const idx = stack.indexOf(this.backdropId);
+      if (idx !== -1) {
+        stack.splice(idx, 1);
+      }
       if (stack.length === 0) {
         Modal.openModalStacks.delete(target);
       }
     }
 
-    const activeBackdropId = stack.length > 0 ? stack[stack.length - 1] : null;
+    const stack = Modal.openModalStacks.get(target);
+    const activeBackdropId = stack?.length ? stack[stack.length - 1] : null;
 
     for (const child of Array.from(target.children)) {
       if (child.hasAttribute('data-popper-placement')) {

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -69,7 +69,7 @@ interface ModalState {
 class Modal extends Component<ModalProps, ModalState> {
   static displayName = 'Modal';
   static currentId = 0;
-  static openModalStack: string[] = [];
+  static openModalStacks: Map<HTMLElement, string[]> = new Map();
   boxId = '';
   backdropId = '';
 
@@ -107,22 +107,31 @@ class Modal extends Component<ModalProps, ModalState> {
     return appendTo || document.body;
   };
 
+  static getStackForTarget(target: HTMLElement): string[] {
+    if (!Modal.openModalStacks.has(target)) {
+      Modal.openModalStacks.set(target, []);
+    }
+    return Modal.openModalStacks.get(target)!;
+  }
+
   toggleSiblingsFromScreenReaders = (hide: boolean) => {
     const { appendTo } = this.props;
     const target: HTMLElement = this.getElement(appendTo);
-    const idx = Modal.openModalStack.indexOf(this.backdropId);
+    const stack = Modal.getStackForTarget(target);
+    const idx = stack.indexOf(this.backdropId);
 
     if (hide && idx === -1) {
-      Modal.openModalStack.push(this.backdropId);
+      stack.push(this.backdropId);
     } else if (!hide && idx !== -1) {
-      Modal.openModalStack.splice(idx, 1);
+      stack.splice(idx, 1);
+      if (stack.length === 0) {
+        Modal.openModalStacks.delete(target);
+      }
     }
 
-    const activeBackdropId =
-      Modal.openModalStack.length > 0 ? Modal.openModalStack[Modal.openModalStack.length - 1] : null;
+    const activeBackdropId = stack.length > 0 ? stack[stack.length - 1] : null;
 
     for (const child of Array.from(target.children)) {
-      // We need to prevent aria-hidden being applied to popper elements appended to document.body
       if (child.hasAttribute('data-popper-placement')) {
         continue;
       }
@@ -154,7 +163,7 @@ class Modal extends Component<ModalProps, ModalState> {
     } else {
       if (prevProps.isOpen !== this.props.isOpen) {
         this.toggleSiblingsFromScreenReaders(false);
-        if (Modal.openModalStack.length === 0) {
+        if (!Modal.openModalStacks.has(target)) {
           target.classList.remove(css(styles.backdropOpen));
         }
       }
@@ -166,7 +175,7 @@ class Modal extends Component<ModalProps, ModalState> {
     const target: HTMLElement = this.getElement(appendTo);
     target.removeEventListener('keydown', this.handleEscKeyClick, false);
     this.toggleSiblingsFromScreenReaders(false);
-    if (Modal.openModalStack.length === 0) {
+    if (!Modal.openModalStacks.has(target)) {
       target.classList.remove(css(styles.backdropOpen));
     }
   }

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -69,6 +69,7 @@ interface ModalState {
 class Modal extends Component<ModalProps, ModalState> {
   static displayName = 'Modal';
   static currentId = 0;
+  static openModalStack: string[] = [];
   boxId = '';
   backdropId = '';
 
@@ -109,12 +110,24 @@ class Modal extends Component<ModalProps, ModalState> {
   toggleSiblingsFromScreenReaders = (hide: boolean) => {
     const { appendTo } = this.props;
     const target: HTMLElement = this.getElement(appendTo);
-    const bodyChildren = target.children;
-    for (const child of Array.from(bodyChildren)) {
-      const isPopperElement = child.hasAttribute('data-popper-placement');
-      if (child.id !== this.backdropId && !isPopperElement) {
-        hide ? child.setAttribute('aria-hidden', '' + hide) : child.removeAttribute('aria-hidden');
+    const idx = Modal.openModalStack.indexOf(this.backdropId);
+
+    if (hide && idx === -1) {
+      Modal.openModalStack.push(this.backdropId);
+    } else if (!hide && idx !== -1) {
+      Modal.openModalStack.splice(idx, 1);
+    }
+
+    const activeBackdropId =
+      Modal.openModalStack.length > 0 ? Modal.openModalStack[Modal.openModalStack.length - 1] : null;
+
+    for (const child of Array.from(target.children)) {
+      // We need to prevent aria-hidden being applied to popper elements appended to document.body
+      if (child.hasAttribute('data-popper-placement')) {
+        continue;
       }
+      const shouldHide = activeBackdropId && child.id !== activeBackdropId;
+      shouldHide ? child.setAttribute('aria-hidden', 'true') : child.removeAttribute('aria-hidden');
     }
   };
 
@@ -140,8 +153,10 @@ class Modal extends Component<ModalProps, ModalState> {
       this.toggleSiblingsFromScreenReaders(true);
     } else {
       if (prevProps.isOpen !== this.props.isOpen) {
-        target.classList.remove(css(styles.backdropOpen));
         this.toggleSiblingsFromScreenReaders(false);
+        if (Modal.openModalStack.length === 0) {
+          target.classList.remove(css(styles.backdropOpen));
+        }
       }
     }
   }
@@ -150,8 +165,10 @@ class Modal extends Component<ModalProps, ModalState> {
     const { appendTo } = this.props;
     const target: HTMLElement = this.getElement(appendTo);
     target.removeEventListener('keydown', this.handleEscKeyClick, false);
-    target.classList.remove(css(styles.backdropOpen));
     this.toggleSiblingsFromScreenReaders(false);
+    if (Modal.openModalStack.length === 0) {
+      target.classList.remove(css(styles.backdropOpen));
+    }
   }
 
   render() {

--- a/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
@@ -83,7 +83,7 @@ const MultipleOpenModals = () => {
 
 describe('Modal', () => {
   beforeEach(() => {
-    Modal.openModalStack = [];
+    Modal.openModalStacks = new Map();
   });
 
   test('Modal creates a container element once for div', () => {
@@ -264,5 +264,56 @@ describe('Modal', () => {
     await user.click(closeButtons[closeButtons.length - 1]);
 
     expect(firstBackdrop).not.toHaveAttribute('aria-hidden');
+  });
+
+  test('modals with different appendTo targets have independent stacks', async () => {
+    const user = userEvent.setup();
+    const targetA = document.createElement('div');
+    const targetB = document.createElement('div');
+    document.body.appendChild(targetA);
+    document.body.appendChild(targetB);
+
+    const siblingA = document.createElement('aside');
+    siblingA.textContent = 'Sibling A';
+    targetA.appendChild(siblingA);
+
+    const siblingB = document.createElement('aside');
+    siblingB.textContent = 'Sibling B';
+    targetB.appendChild(siblingB);
+
+    const DistinctTargetModals = () => {
+      const [isAOpen, setIsAOpen] = useState(true);
+      const [isBOpen, setIsBOpen] = useState(true);
+
+      return (
+        <>
+          <Modal isOpen={isAOpen} appendTo={targetA} onClose={() => setIsAOpen(false)} aria-label="Modal A">
+            Modal A content
+          </Modal>
+          <Modal isOpen={isBOpen} appendTo={targetB} onClose={() => setIsBOpen(false)} aria-label="Modal B">
+            Modal B content
+          </Modal>
+        </>
+      );
+    };
+
+    render(<DistinctTargetModals />);
+
+    expect(siblingA).toHaveAttribute('aria-hidden', 'true');
+    expect(siblingB).toHaveAttribute('aria-hidden', 'true');
+    expect(targetA).toHaveClass(css(styles.backdropOpen));
+    expect(targetB).toHaveClass(css(styles.backdropOpen));
+
+    const closeButtons = screen.getAllByRole('button', { name: 'Close', hidden: true });
+    await user.click(closeButtons[1]);
+
+    expect(targetB).not.toHaveClass(css(styles.backdropOpen));
+    expect(siblingB).not.toHaveAttribute('aria-hidden');
+
+    expect(targetA).toHaveClass(css(styles.backdropOpen));
+    expect(siblingA).toHaveAttribute('aria-hidden', 'true');
+
+    document.body.removeChild(targetA);
+    document.body.removeChild(targetB);
   });
 });

--- a/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
@@ -64,7 +64,28 @@ const ModalWithAdjacentModal = () => {
   );
 };
 
+const MultipleOpenModals = () => {
+  const [isFirstOpen, setIsFirstOpen] = useState(true);
+  const [isSecondOpen, setIsSecondOpen] = useState(false);
+
+  return (
+    <>
+      <aside>Aside sibling</aside>
+      <Modal isOpen={isFirstOpen} appendTo={target} onClose={() => setIsFirstOpen(false)} aria-label="First modal">
+        <button onClick={() => setIsSecondOpen(true)}>Open second modal</button>
+      </Modal>
+      <Modal isOpen={isSecondOpen} appendTo={target} onClose={() => setIsSecondOpen(false)} aria-label="Second modal">
+        Second modal content
+      </Modal>
+    </>
+  );
+};
+
 describe('Modal', () => {
+  beforeEach(() => {
+    Modal.openModalStack = [];
+  });
+
   test('Modal creates a container element once for div', () => {
     render(<Modal {...props} />);
     expect(document.createElement).toHaveBeenCalledWith('div');
@@ -180,5 +201,68 @@ describe('Modal', () => {
       'class',
       'pf-v6-l-bullseye'
     );
+  });
+
+  test('backdropOpen class remains when closing one of multiple open modals', async () => {
+    const user = userEvent.setup();
+
+    render(<MultipleOpenModals />, { container: document.body.appendChild(target) });
+
+    await user.click(screen.getByRole('button', { name: 'Open second modal' }));
+
+    expect(target).toHaveClass(css(styles.backdropOpen));
+
+    const closeButtons = screen.getAllByRole('button', { name: 'Close', hidden: true });
+    await user.click(closeButtons[closeButtons.length - 1]);
+
+    expect(target).toHaveClass(css(styles.backdropOpen));
+  });
+
+  test('backdropOpen class is removed when all modals are closed', async () => {
+    const user = userEvent.setup();
+
+    render(<MultipleOpenModals />, { container: document.body.appendChild(target) });
+
+    await user.click(screen.getByRole('button', { name: 'Open second modal' }));
+
+    const closeButtons = screen.getAllByRole('button', { name: 'Close', hidden: true });
+    await user.click(closeButtons[closeButtons.length - 1]);
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(target).not.toHaveClass(css(styles.backdropOpen));
+  });
+
+  test('only the most recent modal does not have aria-hidden when multiple modals are open', async () => {
+    const user = userEvent.setup();
+
+    render(<MultipleOpenModals />, { container: document.body.appendChild(target) });
+
+    const firstBackdrop = screen.getByLabelText('First modal').closest('[class*="backdrop"]');
+
+    await user.click(screen.getByRole('button', { name: 'Open second modal' }));
+
+    const secondBackdrop = screen.getByLabelText('Second modal').closest('[class*="backdrop"]');
+
+    expect(firstBackdrop).toHaveAttribute('aria-hidden', 'true');
+    expect(secondBackdrop).not.toHaveAttribute('aria-hidden');
+  });
+
+  test('closing the active modal reveals the previous modal', async () => {
+    const user = userEvent.setup();
+
+    render(<MultipleOpenModals />, { container: document.body.appendChild(target) });
+
+    await user.click(screen.getByRole('button', { name: 'Open second modal' }));
+
+    const firstBackdrop = screen
+      .getByLabelText('First modal', { selector: '[role="dialog"]' })
+      .closest('[class*="backdrop"]');
+
+    expect(firstBackdrop).toHaveAttribute('aria-hidden', 'true');
+
+    const closeButtons = screen.getAllByRole('button', { name: 'Close', hidden: true });
+    await user.click(closeButtons[closeButtons.length - 1]);
+
+    expect(firstBackdrop).not.toHaveAttribute('aria-hidden');
   });
 });

--- a/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
@@ -316,4 +316,21 @@ describe('Modal', () => {
     document.body.removeChild(targetA);
     document.body.removeChild(targetB);
   });
+
+  test('unmounting a never-opened modal with a custom target does not leak a stack entry', () => {
+    const customTarget = document.createElement('div');
+    document.body.appendChild(customTarget);
+
+    const { unmount } = render(
+      <Modal isOpen={false} appendTo={customTarget} onClose={() => {}}>
+        Never opened
+      </Modal>
+    );
+
+    unmount();
+
+    expect(Modal.openModalStacks.has(customTarget)).toBe(false);
+
+    document.body.removeChild(customTarget);
+  });
 });

--- a/packages/react-core/src/components/Modal/examples/ModalBasic.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalBasic.tsx
@@ -3,9 +3,13 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/
 
 export const ModalBasic: React.FunctionComponent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModal2Open, setIsModal2Open] = useState(false);
 
   const handleModalToggle = (_event: KeyboardEvent | React.MouseEvent) => {
     setIsModalOpen(!isModalOpen);
+  };
+  const handleModal2Toggle = (_event: KeyboardEvent | React.MouseEvent) => {
+    setIsModal2Open(!isModal2Open);
   };
 
   return (
@@ -27,12 +31,33 @@ export const ModalBasic: React.FunctionComponent = () => {
           consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
           pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
           est laborum.
+          <Button variant="primary" onClick={handleModal2Toggle} ouiaId="ShowBasicModal">
+            Show basic modal
+          </Button>
         </ModalBody>
         <ModalFooter>
           <Button key="confirm" variant="primary" onClick={handleModalToggle}>
             Confirm
           </Button>
           <Button key="cancel" variant="link" onClick={handleModalToggle}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+      <Modal
+        isOpen={isModal2Open}
+        onClose={handleModal2Toggle}
+        ouiaId="BasicModal2"
+        aria-labelledby="basic2-modal-title"
+        aria-describedby="modal2-box-body-basic"
+      >
+        <ModalHeader title="Nested modal" labelId="basic2-modal-title" />
+        <ModalBody id="modal2-box-body-basic">Nested modal</ModalBody>
+        <ModalFooter>
+          <Button key="confirm2" variant="primary" onClick={handleModal2Toggle}>
+            Confirm
+          </Button>
+          <Button key="cancel2" variant="link" onClick={handleModal2Toggle}>
             Cancel
           </Button>
         </ModalFooter>

--- a/packages/react-core/src/components/Modal/examples/ModalBasic.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalBasic.tsx
@@ -3,13 +3,9 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/
 
 export const ModalBasic: React.FunctionComponent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isModal2Open, setIsModal2Open] = useState(false);
 
   const handleModalToggle = (_event: KeyboardEvent | React.MouseEvent) => {
     setIsModalOpen(!isModalOpen);
-  };
-  const handleModal2Toggle = (_event: KeyboardEvent | React.MouseEvent) => {
-    setIsModal2Open(!isModal2Open);
   };
 
   return (
@@ -18,7 +14,6 @@ export const ModalBasic: React.FunctionComponent = () => {
         Show basic modal
       </Button>
       <Modal
-        appendTo={() => document.querySelector('#root') as HTMLElement}
         isOpen={isModalOpen}
         onClose={handleModalToggle}
         ouiaId="BasicModal"
@@ -32,33 +27,12 @@ export const ModalBasic: React.FunctionComponent = () => {
           consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
           pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
           est laborum.
-          <Button variant="primary" onClick={handleModal2Toggle} ouiaId="ShowBasicModal">
-            Show basic modal
-          </Button>
         </ModalBody>
         <ModalFooter>
           <Button key="confirm" variant="primary" onClick={handleModalToggle}>
             Confirm
           </Button>
           <Button key="cancel" variant="link" onClick={handleModalToggle}>
-            Cancel
-          </Button>
-        </ModalFooter>
-      </Modal>
-      <Modal
-        isOpen={isModal2Open}
-        onClose={handleModal2Toggle}
-        ouiaId="BasicModal2"
-        aria-labelledby="basic2-modal-title"
-        aria-describedby="modal2-box-body-basic"
-      >
-        <ModalHeader title="Nested modal" labelId="basic2-modal-title" />
-        <ModalBody id="modal2-box-body-basic">Nested modal</ModalBody>
-        <ModalFooter>
-          <Button key="confirm2" variant="primary" onClick={handleModal2Toggle}>
-            Confirm
-          </Button>
-          <Button key="cancel2" variant="link" onClick={handleModal2Toggle}>
             Cancel
           </Button>
         </ModalFooter>

--- a/packages/react-core/src/components/Modal/examples/ModalBasic.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalBasic.tsx
@@ -18,6 +18,7 @@ export const ModalBasic: React.FunctionComponent = () => {
         Show basic modal
       </Button>
       <Modal
+        appendTo={() => document.querySelector('#root') as HTMLElement}
         isOpen={isModalOpen}
         onClose={handleModalToggle}
         ouiaId="BasicModal"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12608

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening multiple nested modals.
  * The newest modal remains active while previously opened modals are hidden.
  * Closing the active modal reveals the previous modal automatically.
  * Modals opened in different locations maintain independent stacks.
  * Backdrop behavior is preserved until all open modals in that location are closed.
  * Updated the modal example with nested modal controls.

* **Bug Fixes**
  * Improved accessibility handling and visibility management for stacked modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->