### PR TITLE
feat(Nav,Compass,Page): add support for expandable nav items in docked nav

### DIFF
--- a/packages/react-core/src/components/Compass/Compass.tsx
+++ b/packages/react-core/src/components/Compass/Compass.tsx
@@ -10,8 +10,10 @@ export interface CompassProps extends React.HTMLProps<HTMLDivElement> {
   masthead?: React.ReactNode;
   /** Content of the docked navigation area of the layout */
   dock?: React.ReactNode;
-  /** @beta Flag indicating the docked nav is expanded on mobile. Only applies when dock content is passed. */
+  /** @beta Flag indicating the docked nav is expande on mobile. Only applies when dock content is passed. */
   isDockExpanded?: boolean;
+  /** @beta Flag indicating a docked nav is expanded as an overlay, triggered by expandable nav children. Only applies when dock content is passed. */
+  isDockExpandableExpanded?: boolean;
   /** @beta Flag indicating the docked nav should display text on desktop. Only applies when dock content is passed, and
    * will handle toggling the visibility of the text in individual isDocked components.
    */
@@ -45,6 +47,7 @@ export const Compass: React.FunctionComponent<CompassProps> = ({
   masthead,
   dock,
   isDockExpanded,
+  isDockExpandableExpanded,
   isDockTextExpanded,
   header,
   isHeaderExpanded = true,
@@ -69,6 +72,7 @@ export const Compass: React.FunctionComponent<CompassProps> = ({
           className={css(
             `${styles.compass}__dock`,
             isDockExpanded && styles.modifiers.expanded,
+            isDockExpandableExpanded && styles.modifiers.expandableExpanded,
             isDockTextExpanded && styles.modifiers.textExpanded
           )}
         >

--- a/packages/react-core/src/components/Compass/Compass.tsx
+++ b/packages/react-core/src/components/Compass/Compass.tsx
@@ -10,7 +10,7 @@ export interface CompassProps extends React.HTMLProps<HTMLDivElement> {
   masthead?: React.ReactNode;
   /** Content of the docked navigation area of the layout */
   dock?: React.ReactNode;
-  /** @beta Flag indicating the docked nav is expande on mobile. Only applies when dock content is passed. */
+  /** @beta Flag indicating the docked nav is expanded on mobile. Only applies when dock content is passed. */
   isDockExpanded?: boolean;
   /** @beta Flag indicating a docked nav is expanded as an overlay, triggered by expandable nav children. Only applies when dock content is passed. */
   isDockExpandableExpanded?: boolean;

--- a/packages/react-core/src/components/Compass/__tests__/Compass.test.tsx
+++ b/packages/react-core/src/components/Compass/__tests__/Compass.test.tsx
@@ -94,6 +94,21 @@ test('Renders footer without expanded class and with inert when isFooterExpanded
   expect(footerElement).toHaveAttribute('inert');
 });
 
+test(`Renders with ${styles.modifiers.expandableExpanded} class when isDockExpandableExpanded is true`, () => {
+  render(<Compass dock={<div>Dock content</div>} isDockExpandableExpanded />);
+  expect(screen.getByText('Dock content').parentElement).toHaveClass(styles.modifiers.expandableExpanded);
+});
+
+test(`Does not render with ${styles.modifiers.expandableExpanded} class when isDockExpandableExpanded is false`, () => {
+  render(<Compass dock={<div>Dock content</div>} isDockExpandableExpanded={false} />);
+  expect(screen.getByText('Dock content').parentElement).not.toHaveClass(styles.modifiers.expandableExpanded);
+});
+
+test(`Does not render with ${styles.modifiers.expandableExpanded} class by default`, () => {
+  render(<Compass dock={<div>Dock content</div>} />);
+  expect(screen.getByText('Dock content').parentElement).not.toHaveClass(styles.modifiers.expandableExpanded);
+});
+
 test('Renders with drawer when drawerContent is provided', () => {
   render(<Compass drawerContent={<div>Drawer content</div>} />);
   expect(screen.getByText('Drawer content')).toBeVisible();

--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -8,6 +8,7 @@ import { PickOptional } from '../../helpers/typeUtils';
 import { getOUIAProps, OUIAProps } from '../../helpers';
 import { SSRSafeIds } from '../../helpers/SSRSafeIds/SSRSafeIds';
 import { IS_INERT } from '../../helpers/inert';
+import RhUiEllipsisHorizontalFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ellipsis-horizontal-fill-icon';
 
 export interface NavExpandableProps
   extends Omit<React.DetailedHTMLProps<React.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>, 'title'>, OUIAProps {
@@ -17,6 +18,8 @@ export interface NavExpandableProps
   srText?: string;
   /** Boolean to pragmatically expand or collapse section */
   isExpanded?: boolean;
+  /** Adds an expandable icon to indicate the section is expandable */
+  hasExpandableIcon?: boolean;
   /** Anything that can be rendered inside of the expandable list */
   children?: React.ReactNode;
   /** Additional classes added to the container */
@@ -50,7 +53,8 @@ class NavExpandable extends Component<NavExpandableProps, NavExpandableState> {
     className: '',
     groupId: null as string,
     isActive: false,
-    id: ''
+    id: '',
+    hasExpandableIcon: false
   };
 
   state = {
@@ -100,6 +104,7 @@ class NavExpandable extends Component<NavExpandableProps, NavExpandableState> {
       id,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       isExpanded,
+      hasExpandableIcon,
       buttonProps,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onExpand,
@@ -137,7 +142,12 @@ class NavExpandable extends Component<NavExpandableProps, NavExpandableState> {
                         {...buttonProps}
                       >
                         {icon && <span className={css(styles.navLinkIcon)}>{icon}</span>}
-                        {typeof title !== 'string' ? <span className={css(styles.navLinkText)}>{title}</span> : title}
+                        {hasExpandableIcon && (
+                          <span className={css(styles.navLinkExpandableIcon)}>
+                            <RhUiEllipsisHorizontalFillIcon />
+                          </span>
+                        )}
+                        <span className={css(styles.navLinkText)}>{title}</span>
                         <span className={css(styles.navToggle)}>
                           <span className={css(styles.navToggleIcon)}>
                             <RhMicronsCaretDownIcon />

--- a/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavExpandable.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavExpandable.test.tsx.snap
@@ -12,7 +12,11 @@ exports[`NavExpandable should match snapshot (auto-generated) 1`] = `
       aria-expanded="false"
       class="pf-v6-c-nav__link"
     >
-      string
+      <span
+        class="pf-v6-c-nav__link-text"
+      >
+        string
+      </span>
       <span
         class="pf-v6-c-nav__toggle"
       >

--- a/packages/react-core/src/components/Nav/__tests__/NavExpandable.test.tsx
+++ b/packages/react-core/src/components/Nav/__tests__/NavExpandable.test.tsx
@@ -30,3 +30,24 @@ test('Does not render nav link icon wrapper when icon prop is not provided', () 
   const button = screen.getByRole('button', { name: 'NavExpandable' });
   expect(button.querySelector('.pf-v6-c-nav__link-icon')).not.toBeInTheDocument();
 });
+
+test(`Renders with expandable icon when hasExpandableIcon is true`, () => {
+  render(<NavExpandable id="grp-1" title="NavExpandable" hasExpandableIcon={true}></NavExpandable>);
+
+  const button = screen.getByRole('button', { name: 'NavExpandable' });
+  expect(button.querySelector('.pf-v6-c-nav__link-expandable-icon')).toBeInTheDocument();
+});
+
+test(`Does not render expandable icon when hasExpandableIcon is false`, () => {
+  render(<NavExpandable id="grp-1" title="NavExpandable" hasExpandableIcon={false}></NavExpandable>);
+
+  const button = screen.getByRole('button', { name: 'NavExpandable' });
+  expect(button.querySelector('.pf-v6-c-nav__link-expandable-icon')).not.toBeInTheDocument();
+});
+
+test(`Does not render expandable icon by default`, () => {
+  render(<NavExpandable id="grp-1" title="NavExpandable"></NavExpandable>);
+
+  const button = screen.getByRole('button', { name: 'NavExpandable' });
+  expect(button.querySelector('.pf-v6-c-nav__link-expandable-icon')).not.toBeInTheDocument();
+});

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -196,7 +196,11 @@ exports[`Nav Expandable Nav List - Trigger toggle 1`] = `
           class="pf-v6-c-nav__link"
           id="grp-1"
         >
-          Section 1
+          <span
+            class="pf-v6-c-nav__link-text"
+          >
+            Section 1
+          </span>
           <span
             class="pf-v6-c-nav__toggle"
           >
@@ -329,7 +333,11 @@ exports[`Nav Expandable Nav List 1`] = `
           class="pf-v6-c-nav__link"
           id="grp-1"
         >
-          Section 1
+          <span
+            class="pf-v6-c-nav__link-text"
+          >
+            Section 1
+          </span>
           <span
             class="pf-v6-c-nav__toggle"
           >
@@ -461,7 +469,11 @@ exports[`Nav Expandable Nav List with aria label 1`] = `
           aria-expanded="false"
           class="pf-v6-c-nav__link"
         >
-          Section 1
+          <span
+            class="pf-v6-c-nav__link-text"
+          >
+            Section 1
+          </span>
           <span
             class="pf-v6-c-nav__toggle"
           >

--- a/packages/react-core/src/components/Nav/examples/Nav.md
+++ b/packages/react-core/src/components/Nav/examples/Nav.md
@@ -84,7 +84,7 @@ A flyout should be a `Menu` component. Press `space` or `right arrow` to open a 
 
 ### Docked
 
-The docked variant of `Navigation` displays only icons passed to child `NavItems` or `NavExpandable`. Text becomes visible when `.pf-m-text-expanded` or `.pf-m-expandable-expanded` are applied to an outer page or compass dock.
+The docked variant of `Navigation` displays only icons passed to child `NavItems` or `NavExpandable`. Text becomes visible when `isDockTextExpanded` or `isDockExpandableExpanded` are applied to an outer page or compass dock.
 
 `NavExpandable` items should include the `hasExpandableIcon` prop to indicate their expandable nature while in the collapsed state of the docked nav as the caret will not be rendered.
 

--- a/packages/react-core/src/components/Nav/examples/Nav.md
+++ b/packages/react-core/src/components/Nav/examples/Nav.md
@@ -9,11 +9,12 @@ ouia: true
 import { useState } from 'react';
 import './nav.css';
 import RhMicronsCaretRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-caret-right-icon';
-import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
-import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
-import RhUiFolderOpenFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-open-fill-icon';
-import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiFolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-open-icon';
+import RhUiCloudIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-icon';
 import RhUiLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-link-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 
 ## Examples
 
@@ -78,6 +79,18 @@ A flyout should be a `Menu` component. Press `space` or `right arrow` to open a 
 ### With icons
 
 ```ts file="./NavIcons.tsx"
+
+```
+
+### Docked
+
+The docked variant of `Navigation` displays only icons passed to child `NavItems` or `NavExpandable`. Text becomes visible when `.pf-m-text-expanded` or `.pf-m-expandable-expanded` are applied to an outer page or compass dock.
+
+`NavExpandable` items should include the `hasExpandableIcon` prop to indicate their expandable nature while in the collapsed state of the docked nav as the caret will not be rendered.
+
+See the [docked nav demo](/components/navigation/react-demos#docked-nav) for a fully functional example.
+
+```ts file="./NavDocked.tsx"
 
 ```
 

--- a/packages/react-core/src/components/Nav/examples/NavDocked.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavDocked.tsx
@@ -59,6 +59,7 @@ export const NavDocked: React.FunctionComponent = () => {
           icon={<RhUiFolderIcon />}
           isExpanded={isGroupExpanded}
           hasExpandableIcon
+          buttonProps={{ 'aria-label': 'Expandable Group 1' }}
         >
           <NavItem
             preventDefault

--- a/packages/react-core/src/components/Nav/examples/NavDocked.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavDocked.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { Nav, NavItem, NavList, NavExpandable } from '@patternfly/react-core';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
+import RhUiCloudIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-icon';
+
+export const NavDocked: React.FunctionComponent = () => {
+  const [activeItem, setActiveItem] = useState(0);
+  const [isGroupExpanded, setIsGroupExpanded] = useState(false);
+
+  const onSelect = (_event: React.FormEvent<HTMLInputElement>, result: { itemId: number | string }) => {
+    setActiveItem(result.itemId as number);
+  };
+
+  const onToggle = (
+    _event: React.MouseEvent<HTMLButtonElement>,
+    result: { groupId: number | string; isExpanded: boolean }
+  ) => {
+    setIsGroupExpanded(result.isExpanded);
+  };
+
+  return (
+    <Nav variant="docked" onSelect={onSelect} onToggle={onToggle} aria-label="Default global" ouiaId="DefaultNav">
+      <NavList>
+        <NavItem
+          icon={<RhUiCubesIcon />}
+          preventDefault
+          id="nav-default-link1"
+          to="#nav-default-link1"
+          itemId={0}
+          isActive={activeItem === 0}
+        >
+          Default Link 1
+        </NavItem>
+        <NavItem
+          icon={<RhUiCloudIcon />}
+          preventDefault
+          id="nav-default-link2"
+          to="#nav-default-link2"
+          itemId={1}
+          isActive={activeItem === 1}
+        >
+          Default Link 2
+        </NavItem>
+        <NavItem
+          icon={<RhUiCodeIcon />}
+          preventDefault
+          id="nav-default-link3"
+          to="#nav-default-link3"
+          itemId={2}
+          isActive={activeItem === 2}
+        >
+          Default Link 3
+        </NavItem>
+        <NavExpandable
+          title="Expandable Group 1"
+          groupId="nav-expandable-group-1"
+          icon={<RhUiFolderIcon />}
+          isExpanded={isGroupExpanded}
+          hasExpandableIcon
+        >
+          <NavItem
+            preventDefault
+            id="expandable-1"
+            to="#expandable-1"
+            groupId="nav-expandable-group-1"
+            itemId={3}
+            isActive={activeItem === 3}
+          >
+            Subnav 1 Link 1
+          </NavItem>
+          <NavItem
+            preventDefault
+            id="expandable-2"
+            to="#expandable-2"
+            groupId="nav-expandable-group-1"
+            itemId={4}
+            isActive={activeItem === 4}
+          >
+            Subnav 1 Link 2
+          </NavItem>
+          <NavItem
+            preventDefault
+            id="expandable-3"
+            to="#expandable-3"
+            groupId="nav-expandable-group-1"
+            itemId={5}
+            isActive={activeItem === 5}
+          >
+            Subnav 1 Link 3
+          </NavItem>
+        </NavExpandable>
+      </NavList>
+    </Nav>
+  );
+};

--- a/packages/react-core/src/components/Nav/examples/NavIcons.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavIcons.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
-import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
-import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
-import RhUiFolderOpenFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-open-fill-icon';
-import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiFolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-open-icon';
+import RhUiCloudIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-icon';
 import RhUiLinkIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-link-icon';
 
 export const NavIcons: React.FunctionComponent = () => {
@@ -22,7 +22,7 @@ export const NavIcons: React.FunctionComponent = () => {
           to="#nav-icon-link1"
           itemId={0}
           isActive={activeItem === 0}
-          icon={<CubeIcon />}
+          icon={<RhUiCubesIcon />}
         >
           Link 1
         </NavItem>
@@ -32,7 +32,7 @@ export const NavIcons: React.FunctionComponent = () => {
           to="#nav-icon-link2"
           itemId={1}
           isActive={activeItem === 1}
-          icon={<RhUiFolderFillIcon />}
+          icon={<RhUiFolderIcon />}
         >
           Link 2
         </NavItem>
@@ -42,7 +42,7 @@ export const NavIcons: React.FunctionComponent = () => {
           to="#nav-icon-link3"
           itemId={2}
           isActive={activeItem === 2}
-          icon={<RhUiCloudFillIcon />}
+          icon={<RhUiCloudIcon />}
         >
           Link 3
         </NavItem>
@@ -56,7 +56,7 @@ export const NavIcons: React.FunctionComponent = () => {
         >
           Link 4
         </NavItem>
-        <NavExpandable title="Expandable" icon={<RhUiFolderOpenFillIcon />} groupId="nav-icon-expandable">
+        <NavExpandable title="Expandable" icon={<RhUiFolderOpenIcon />} groupId="nav-icon-expandable">
           <NavItem
             preventDefault
             id="nav-icon-expandable-link1"

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -24,6 +24,8 @@ export interface PageProps extends React.HTMLProps<HTMLDivElement> {
   variant?: 'default' | 'docked';
   /** @beta Flag indicating the docked nav is expanded on mobile. Only applies when variant is docked. */
   isDockExpanded?: boolean;
+  /** @beta Flag indicating a docked nav is expanded as an overlay, triggered by expandable nav children. Only applies when dock content is passed. */
+  isDockExpandableExpanded?: boolean;
   /** @beta Flag indicating the docked nav should display text on desktop. Only applies when variant is docked, and
    * will handle toggling the visibility of the text in individual isDocked components.
    */
@@ -134,6 +136,7 @@ class Page extends Component<PageProps, PageState> {
     defaultManagedSidebarIsOpen: true,
     mainTabIndex: -1,
     isNotificationDrawerExpanded: false,
+    isDockExpandableExpanded: false,
     onNotificationDrawerExpand: () => null,
     mainComponent: 'main',
     getBreakpoint,
@@ -248,6 +251,7 @@ class Page extends Component<PageProps, PageState> {
       variant,
       isDockExpanded = false,
       isDockTextExpanded = false,
+      isDockExpandableExpanded = false,
       masthead,
       dockContent,
       sidebar,
@@ -374,6 +378,7 @@ class Page extends Component<PageProps, PageState> {
                 className={css(
                   styles.pageDock,
                   isDockExpanded && styles.modifiers.expanded,
+                  isDockExpandableExpanded && styles.modifiers.expandableExpanded,
                   isDockTextExpanded && styles.modifiers.textExpanded
                 )}
               >

--- a/packages/react-core/src/components/Page/__tests__/Page.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/Page.test.tsx
@@ -482,6 +482,26 @@ describe('Page docked variant', () => {
     expect(pageDock).toHaveClass(styles.modifiers.textExpanded);
   });
 
+  test(`Does not render with ${styles.modifiers.expandableExpanded} when by default and variant is docked`, () => {
+    render(<Page variant="docked" dockContent={<>Dock content</>} masthead={<>Masthead</>} data-testid="page"></Page>);
+    const pageDock = screen.getByText('Dock content').closest(`.${styles.pageDock}`);
+    expect(pageDock).not.toHaveClass(styles.modifiers.expandableExpanded);
+  });
+
+  test(`Renders with ${styles.modifiers.expandableExpanded} when isDockExpandableExpanded is true and variant is docked`, () => {
+    render(
+      <Page
+        variant="docked"
+        isDockExpandableExpanded
+        dockContent={<>Dock content</>}
+        masthead={<>Masthead</>}
+        data-testid="page"
+      ></Page>
+    );
+    const pageDock = screen.getByText('Dock content').closest(`.${styles.pageDock}`);
+    expect(pageDock).toHaveClass(styles.modifiers.expandableExpanded);
+  });
+
   test(`Renders with ${styles.pageDockMain} wrapper when variant is docked`, () => {
     render(<Page variant="docked" dockContent={<>Dock content</>} masthead={<>Masthead</>} data-testid="page"></Page>);
 

--- a/packages/react-core/src/demos/Compass/Compass.md
+++ b/packages/react-core/src/demos/Compass/Compass.md
@@ -8,7 +8,6 @@ import RhUiPlayFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-play-
 import RhUiAddSquareIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-add-square-icon';
 import RhUiCopyIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-copy-icon';
 import RhUiQuestionMarkCircleIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-icon';
-import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
 import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
@@ -18,6 +17,9 @@ import imgAvatar from '../assets/avatarImg.svg';
 import RhUiThumbnailViewSmallFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-thumbnail-view-small-fill-icon';
 import pfLogo from '../assets/PF-IconLogo-color.svg';
 import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_lg';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiResourceIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-resource-icon';
 
 ## Demos
 

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -26,14 +26,17 @@ import {
   Button,
   Tooltip,
   Divider,
-  PageToggleButton
+  PageToggleButton,
+  NavExpandable
 } from '@patternfly/react-core';
-import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
 import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiResourceIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-resource-icon';
 import pfLogo from '../../assets/PF-IconLogo-color.svg';
 import RhUiThumbnailViewSmallFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-thumbnail-view-small-fill-icon';
 import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_lg';
@@ -46,8 +49,10 @@ interface NavOnSelectProps {
 
 export const CompassDockDemo: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = useState<number>(0);
+  const [isNavGroupExpanded, setIsNavGroupExpanded] = useState(false);
   const [isDockExpanded, setIsDockExpanded] = useState(false);
   const [isDockTextExpanded, setIsDockTextExpanded] = useState(false);
+  const [isDockExpandableExpanded, setIsDockExpandableExpanded] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -65,6 +70,11 @@ export const CompassDockDemo: React.FunctionComponent = () => {
 
   const onNavSelect = (_event: React.FormEvent<HTMLInputElement>, selectedItem: NavOnSelectProps) => {
     typeof selectedItem.itemId === 'number' && setActiveItem(selectedItem.itemId);
+
+    setIsNavGroupExpanded(false);
+    setIsDockExpandableExpanded(false);
+    setIsDockTextExpanded(false);
+    setIsDockExpanded(false);
   };
 
   const navItem1Ref = useRef<HTMLAnchorElement>(null);
@@ -95,7 +105,34 @@ export const CompassDockDemo: React.FunctionComponent = () => {
         }, 200);
       }
     } else {
-      setIsDockTextExpanded(!isDockTextExpanded);
+      const nextDockTextExpanded = !isDockTextExpanded;
+      setIsDockTextExpanded(nextDockTextExpanded);
+
+      if (!nextDockTextExpanded) {
+        setIsDockExpandableExpanded(false);
+      }
+
+      if (isDockExpandableExpanded) {
+        setIsDockExpandableExpanded(false);
+        setIsDockTextExpanded(false);
+      }
+    }
+  };
+
+  const onToggleNavGroup = (
+    _event: React.MouseEvent<HTMLButtonElement>,
+    result: { groupId: number | string; isExpanded: boolean }
+  ) => {
+    setIsNavGroupExpanded(result.isExpanded);
+
+    if (!isMobile) {
+      if (!isDockExpandableExpanded && !isDockTextExpanded) {
+        setIsDockExpandableExpanded(true);
+      }
+
+      if (!isDockTextExpanded) {
+        setIsDockTextExpanded(false);
+      }
     }
   };
 
@@ -246,7 +283,13 @@ export const CompassDockDemo: React.FunctionComponent = () => {
           <Toolbar id="toolbar" isVertical>
             <ToolbarContent>
               <ToolbarItem>
-                <Nav onSelect={onNavSelect} variant="docked" aria-label="Global" ouiaId="IconNav">
+                <Nav
+                  onSelect={onNavSelect}
+                  onToggle={onToggleNavGroup}
+                  variant="docked"
+                  aria-label="Global"
+                  ouiaId="IconNav"
+                >
                   <NavList>
                     <NavItem
                       key="nav-icon-link1"
@@ -255,12 +298,31 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                       to="#nav-icon-link1"
                       itemId={0}
                       isActive={activeItem === 0}
-                      icon={<CubeIcon />}
+                      icon={<RhUiCubesIcon />}
                       anchorRef={navItem1Ref}
                       aria-label="System panel"
                     >
                       System panel
                     </NavItem>
+                    <NavExpandable
+                      title="Policy"
+                      groupId={4}
+                      isExpanded={isNavGroupExpanded}
+                      icon={<RhUiFolderIcon />}
+                      hasExpandableIcon={!isMobile}
+                    >
+                      <NavItem
+                        preventDefault
+                        id="expandable3rd-1"
+                        to="#expandable3rd-1"
+                        groupId="nav-expand3rd-group-1"
+                        itemId={5}
+                        isActive={activeItem === 5}
+                        icon={<RhUiResourceIcon />}
+                      >
+                        Subnav link 1
+                      </NavItem>
+                    </NavExpandable>
                     <NavItem
                       key="nav-icon-link2"
                       preventDefault
@@ -405,6 +467,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
       masthead={mobileMasthead}
       dock={dockContent}
       isDockExpanded={isDockExpanded}
+      isDockExpandableExpanded={isDockExpandableExpanded}
       isDockTextExpanded={isDockTextExpanded}
       main={mainContent}
       backgroundSrcDark="/assets/images/pf-background.svg"

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -411,7 +411,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                     </NavItem>
                   </NavList>
                 </Nav>
-                {!isDockTextExpanded && !isDockExpanded && (
+                {!isDockTextExpanded && !isDockExpanded && !isDockExpandableExpanded && (
                   <>
                     <Tooltip aria="none" aria-live="off" triggerRef={navItem1Ref} content="System panel"></Tooltip>
                     <Tooltip aria="none" aria-live="off" triggerRef={navItem2Ref} content="Policy"></Tooltip>

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -353,8 +353,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                       isExpanded={isNavGroupExpanded}
                       icon={<RhUiFolderIcon />}
                       hasExpandableIcon={!isMobile}
-                      buttonProps={{ ref: navItem5Ref }}
-                      aria-label="Folder"
+                      buttonProps={{ ref: navItem5Ref, 'aria-label': 'Folder' }}
                     >
                       <NavItem
                         preventDefault

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -68,6 +68,46 @@ export const CompassDockDemo: React.FunctionComponent = () => {
     return () => mediaQuery.removeEventListener('change', handleResize);
   }, []);
 
+  const handleDockClickOutside = (event: MouseEvent) => {
+    if ((!isMobile && !isDockExpandableExpanded) || (isMobile && !isDockExpanded)) {
+      return;
+    }
+
+    const dockedMastheadElement = document.getElementById('docked-masthead');
+    const dockedMobileMasthead = document.getElementById('mobile-masthead');
+
+    if (
+      dockedMastheadElement &&
+      !dockedMastheadElement.contains(event.target as Node) &&
+      !dockedMobileMasthead?.contains(event.target as Node) &&
+      (isDockExpandableExpanded || isDockExpanded)
+    ) {
+      setIsDockExpandableExpanded(false);
+      setIsDockExpanded(false);
+    }
+  };
+
+  const handleDockKeydown = (_event: KeyboardEvent) => {
+    if ((!isMobile && !isDockExpandableExpanded) || (isMobile && !isDockExpanded)) {
+      return;
+    }
+
+    if (_event.key === 'Escape') {
+      setIsDockExpandableExpanded(false);
+      setIsDockExpanded(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('click', handleDockClickOutside);
+    window.addEventListener('keydown', handleDockKeydown);
+
+    return () => {
+      window.removeEventListener('click', handleDockClickOutside);
+      window.removeEventListener('keydown', handleDockKeydown);
+    };
+  }, [isDockExpandableExpanded, isDockTextExpanded, isDockExpanded, isMobile]);
+
   const onNavSelect = (_event: React.FormEvent<HTMLInputElement>, selectedItem: NavOnSelectProps) => {
     typeof selectedItem.itemId === 'number' && setActiveItem(selectedItem.itemId);
 
@@ -81,6 +121,8 @@ export const CompassDockDemo: React.FunctionComponent = () => {
   const navItem2Ref = useRef<HTMLAnchorElement>(null);
   const navItem3Ref = useRef<HTMLAnchorElement>(null);
   const navItem4Ref = useRef<HTMLAnchorElement>(null);
+  const navItem5Ref = useRef<HTMLAnchorElement>(null);
+  const navItem6Ref = useRef<HTMLAnchorElement>(null);
   const settingsRef = useRef<HTMLButtonElement>(null);
   const helpRef = useRef<HTMLButtonElement>(null);
   const appsRef = useRef<HTMLButtonElement>(null);
@@ -305,11 +347,13 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                       System panel
                     </NavItem>
                     <NavExpandable
-                      title="Policy"
+                      title="Folder"
                       groupId={4}
                       isExpanded={isNavGroupExpanded}
                       icon={<RhUiFolderIcon />}
                       hasExpandableIcon={!isMobile}
+                      buttonProps={{ ref: navItem5Ref }}
+                      aria-label="Folder"
                     >
                       <NavItem
                         preventDefault
@@ -319,6 +363,8 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                         itemId={5}
                         isActive={activeItem === 5}
                         icon={<RhUiResourceIcon />}
+                        anchorRef={navItem6Ref}
+                        aria-label="Subnav link 1"
                       >
                         Subnav link 1
                       </NavItem>
@@ -370,6 +416,8 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                     <Tooltip aria="none" aria-live="off" triggerRef={navItem2Ref} content="Policy"></Tooltip>
                     <Tooltip aria="none" aria-live="off" triggerRef={navItem3Ref} content="Authentication"></Tooltip>
                     <Tooltip aria="none" aria-live="off" triggerRef={navItem4Ref} content="Network services"></Tooltip>
+                    <Tooltip aria="none" aria-live="off" triggerRef={navItem5Ref} content="Folder"></Tooltip>
+                    <Tooltip aria="none" aria-live="off" triggerRef={navItem6Ref} content="Subnav link 1"></Tooltip>
                   </>
                 )}
               </ToolbarItem>

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -111,7 +111,6 @@ export const CompassDockDemo: React.FunctionComponent = () => {
   const onNavSelect = (_event: React.FormEvent<HTMLInputElement>, selectedItem: NavOnSelectProps) => {
     typeof selectedItem.itemId === 'number' && setActiveItem(selectedItem.itemId);
 
-    setIsNavGroupExpanded(false);
     setIsDockExpandableExpanded(false);
     setIsDockTextExpanded(false);
     setIsDockExpanded(false);
@@ -161,11 +160,12 @@ export const CompassDockDemo: React.FunctionComponent = () => {
     }
   };
 
-  const onToggleNavGroup = (
-    _event: React.MouseEvent<HTMLButtonElement>,
-    result: { groupId: number | string; isExpanded: boolean }
-  ) => {
-    setIsNavGroupExpanded(result.isExpanded);
+  const onToggleNavGroup = (_event: React.MouseEvent<HTMLButtonElement>, isExpanded: boolean) => {
+    if (!isDockExpandableExpanded) {
+      setIsNavGroupExpanded(true);
+    } else {
+      setIsNavGroupExpanded(isExpanded);
+    }
 
     if (!isMobile) {
       if (!isDockExpandableExpanded && !isDockTextExpanded) {
@@ -326,13 +326,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
           <Toolbar id="toolbar" isVertical>
             <ToolbarContent>
               <ToolbarItem>
-                <Nav
-                  onSelect={onNavSelect}
-                  onToggle={onToggleNavGroup}
-                  variant="docked"
-                  aria-label="Global"
-                  ouiaId="IconNav"
-                >
+                <Nav onSelect={onNavSelect} variant="docked" aria-label="Global" ouiaId="IconNav">
                   <NavList>
                     <NavItem
                       key="nav-icon-link1"
@@ -354,6 +348,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
                       icon={<RhUiFolderIcon />}
                       hasExpandableIcon={!isMobile}
                       buttonProps={{ ref: navItem5Ref, 'aria-label': 'Folder' }}
+                      onExpand={onToggleNavGroup}
                     >
                       <NavItem
                         preventDefault

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -74,12 +74,12 @@ export const CompassDockDemo: React.FunctionComponent = () => {
     }
 
     const dockedMastheadElement = document.getElementById('docked-masthead');
-    const dockedMobileMasthead = document.getElementById('mobile-masthead');
+    const dockedMobileMastheadToggle = document.getElementById('mobile-masthead-toggle');
 
     if (
       dockedMastheadElement &&
       !dockedMastheadElement.contains(event.target as Node) &&
-      !dockedMobileMasthead?.contains(event.target as Node) &&
+      !dockedMobileMastheadToggle?.contains(event.target as Node) &&
       (isDockExpandableExpanded || isDockExpanded)
     ) {
       setIsDockExpandableExpanded(false);
@@ -280,6 +280,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
             isSidebarOpen={isDockExpanded}
             onSidebarToggle={onMobileToggle}
             isHamburgerButton
+            id="mobile-masthead-toggle"
           />
         </MastheadToggle>
         <MastheadBrand>

--- a/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
+++ b/packages/react-core/src/demos/Compass/examples/CompassDockDemo.tsx
@@ -161,7 +161,7 @@ export const CompassDockDemo: React.FunctionComponent = () => {
   };
 
   const onToggleNavGroup = (_event: React.MouseEvent<HTMLButtonElement>, isExpanded: boolean) => {
-    if (!isDockExpandableExpanded) {
+    if (!isDockExpandableExpanded && !isDockTextExpanded && !isDockExpanded) {
       setIsNavGroupExpanded(true);
     } else {
       setIsNavGroupExpanded(isExpanded);

--- a/packages/react-core/src/demos/Nav.md
+++ b/packages/react-core/src/demos/Nav.md
@@ -20,7 +20,7 @@ import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-micro
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';
 import { DashboardBreadcrumb } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import { DashboardHeader } from '@patternfly/react-core/dist/js/demos/DashboardHeader';
-import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl';
+import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_lg';
 import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
 import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
 import RhUiResourceIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-resource-icon';

--- a/packages/react-core/src/demos/Nav.md
+++ b/packages/react-core/src/demos/Nav.md
@@ -12,7 +12,6 @@ import RhUiNotificationFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-
 import RhUiMenuBarsIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-menu-bars-icon';
 import imgAvatar from '@patternfly/react-core/src/components/assets/avatarImg.svg';
 import pfLogo from '@patternfly/react-core/src/demos/assets/PF-HorizontalLogo-Color.svg';
-import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
@@ -22,6 +21,9 @@ import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-colo
 import { DashboardBreadcrumb } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 import { DashboardHeader } from '@patternfly/react-core/dist/js/demos/DashboardHeader';
 import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiResourceIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-resource-icon';
 
 ## Demos
 

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -77,12 +77,12 @@ export const NavDockedNav: React.FunctionComponent = () => {
     }
 
     const dockedMastheadElement = document.getElementById('docked-masthead');
-    const dockedMobileMasthead = document.getElementById('mobile-masthead');
+    const dockedMobileMastheadToggle = document.getElementById('mobile-masthead-toggle');
 
     if (
       dockedMastheadElement &&
       !dockedMastheadElement.contains(event.target as Node) &&
-      !dockedMobileMasthead?.contains(event.target as Node) &&
+      !dockedMobileMastheadToggle?.contains(event.target as Node) &&
       (isDockExpandableExpanded || isDockExpanded)
     ) {
       setIsDockExpandableExpanded(false);
@@ -300,6 +300,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
             isSidebarOpen={isDockExpanded}
             onSidebarToggle={onMobileToggle}
             isHamburgerButton
+            id="mobile-masthead-toggle"
           />
         </MastheadToggle>
         <MastheadBrand>

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -370,8 +370,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
                     isExpanded={isNavGroupExpanded}
                     icon={<RhUiFolderIcon />}
                     hasExpandableIcon={!isMobile}
-                    buttonProps={{ ref: navItem5Ref }}
-                    aria-label="Folder"
+                    buttonProps={{ ref: navItem5Ref, 'aria-label': 'Folder' }}
                   >
                     <NavItem
                       preventDefault

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -425,7 +425,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
                   </NavItem>
                 </NavList>
               </Nav>
-              {!isDockTextExpanded && !isDockExpanded && (
+              {!isDockTextExpanded && !isDockExpanded && !isDockExpandableExpanded && (
                 <>
                   <Tooltip aria="none" aria-live="off" triggerRef={navItem1Ref} content="System panel"></Tooltip>
                   <Tooltip aria="none" aria-live="off" triggerRef={navItem2Ref} content="Policy"></Tooltip>

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -41,7 +41,7 @@ import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-ic
 import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
 import RhUiResourceIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-resource-icon';
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';
-import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl';
+import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_lg';
 import { IS_INERT } from '../../../helpers/inert';
 
 interface NavOnSelectProps {
@@ -59,7 +59,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const mobileBreakpoint = Number.parseInt(globalBreakpointXl.value) * 16;
+    const mobileBreakpoint = Number.parseInt(globalBreakpointLg.value) * 16;
     const mediaQuery = window.matchMedia(`(max-width: ${mobileBreakpoint}px)`);
     const handleResize = (e: MediaQueryListEvent | MediaQueryList) => {
       setIsMobile(e.matches);
@@ -70,6 +70,46 @@ export const NavDockedNav: React.FunctionComponent = () => {
 
     return () => mediaQuery.removeEventListener('change', handleResize);
   }, []);
+
+  const handleDockClickOutside = (event: MouseEvent) => {
+    if ((!isMobile && !isDockExpandableExpanded) || (isMobile && !isDockExpanded)) {
+      return;
+    }
+
+    const dockedMastheadElement = document.getElementById('docked-masthead');
+    const dockedMobileMasthead = document.getElementById('mobile-masthead');
+
+    if (
+      dockedMastheadElement &&
+      !dockedMastheadElement.contains(event.target as Node) &&
+      !dockedMobileMasthead?.contains(event.target as Node) &&
+      (isDockExpandableExpanded || isDockExpanded)
+    ) {
+      setIsDockExpandableExpanded(false);
+      setIsDockExpanded(false);
+    }
+  };
+
+  const handleDockKeydown = (_event: KeyboardEvent) => {
+    if ((!isMobile && !isDockExpandableExpanded) || (isMobile && !isDockExpanded)) {
+      return;
+    }
+
+    if (_event.key === 'Escape') {
+      setIsDockExpandableExpanded(false);
+      setIsDockExpanded(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('click', handleDockClickOutside);
+    window.addEventListener('keydown', handleDockKeydown);
+
+    return () => {
+      window.removeEventListener('click', handleDockClickOutside);
+      window.removeEventListener('keydown', handleDockKeydown);
+    };
+  }, [isDockExpandableExpanded, isDockTextExpanded, isDockExpanded, isMobile]);
 
   const onNavSelect = (_event: React.FormEvent<HTMLInputElement>, selectedItem: NavOnSelectProps) => {
     typeof selectedItem.itemId === 'number' && setActiveItem(selectedItem.itemId);
@@ -191,6 +231,8 @@ export const NavDockedNav: React.FunctionComponent = () => {
   const navItem2Ref = useRef<HTMLAnchorElement>(null);
   const navItem3Ref = useRef<HTMLAnchorElement>(null);
   const navItem4Ref = useRef<HTMLAnchorElement>(null);
+  const navItem5Ref = useRef<HTMLAnchorElement>(null);
+  const navItem6Ref = useRef<HTMLAnchorElement>(null);
   const appsRef = useRef<HTMLButtonElement>(null);
   const settingsRef = useRef<HTMLButtonElement>(null);
   const helpRef = useRef<HTMLButtonElement>(null);
@@ -322,20 +364,24 @@ export const NavDockedNav: React.FunctionComponent = () => {
                     System panel
                   </NavItem>
                   <NavExpandable
-                    title="Policy"
-                    groupId={4}
+                    title="Folder"
+                    groupId="nav-expandable-group-1"
                     isExpanded={isNavGroupExpanded}
                     icon={<RhUiFolderIcon />}
                     hasExpandableIcon={!isMobile}
+                    buttonProps={{ ref: navItem5Ref }}
+                    aria-label="Folder"
                   >
                     <NavItem
                       preventDefault
-                      id="expandable3rd-1"
-                      to="#expandable3rd-1"
-                      groupId="nav-expand3rd-group-1"
+                      id="nav-expandable-item-1"
+                      to="#nav-expandable-item-1"
+                      groupId="nav-expandable-group-1"
                       itemId={5}
                       isActive={activeItem === 5}
                       icon={<RhUiResourceIcon />}
+                      anchorRef={navItem6Ref}
+                      aria-label="Subnav link 1"
                     >
                       Subnav link 1
                     </NavItem>
@@ -384,6 +430,8 @@ export const NavDockedNav: React.FunctionComponent = () => {
                   <Tooltip aria="none" aria-live="off" triggerRef={navItem2Ref} content="Policy"></Tooltip>
                   <Tooltip aria="none" aria-live="off" triggerRef={navItem3Ref} content="Authentication"></Tooltip>
                   <Tooltip aria="none" aria-live="off" triggerRef={navItem4Ref} content="Network services"></Tooltip>
+                  <Tooltip aria="none" aria-live="off" triggerRef={navItem5Ref} content="Folder"></Tooltip>
+                  <Tooltip aria="none" aria-live="off" triggerRef={navItem6Ref} content="Subnav link 1"></Tooltip>
                 </>
               )}
             </ToolbarItem>

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -28,15 +28,18 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Tooltip
+  Tooltip,
+  NavExpandable
 } from '@patternfly/react-core';
 import RhUiQuestionMarkCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-question-mark-circle-fill-icon';
-import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import RhUiFolderFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-fill-icon';
 import RhUiCloudFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cloud-fill-icon';
 import RhUiCodeIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-code-icon';
 import RhUiThumbnailViewSmallFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-thumbnail-view-small-fill-icon';
 import RhMicronsSearchIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-search-icon';
+import RhUiCubesIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-cubes-icon';
+import RhUiFolderIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-folder-icon';
+import RhUiResourceIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-resource-icon';
 import pfIconLogo from '@patternfly/react-core/src/demos/assets/PF-IconLogo-color.svg';
 import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl';
 import { IS_INERT } from '../../../helpers/inert';
@@ -49,8 +52,10 @@ interface NavOnSelectProps {
 
 export const NavDockedNav: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = useState(1);
+  const [isNavGroupExpanded, setIsNavGroupExpanded] = useState(false);
   const [isDockExpanded, setIsDockExpanded] = useState(false);
   const [isDockTextExpanded, setIsDockTextExpanded] = useState(false);
+  const [isDockExpandableExpanded, setIsDockExpandableExpanded] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -68,6 +73,11 @@ export const NavDockedNav: React.FunctionComponent = () => {
 
   const onNavSelect = (_event: React.FormEvent<HTMLInputElement>, selectedItem: NavOnSelectProps) => {
     typeof selectedItem.itemId === 'number' && setActiveItem(selectedItem.itemId);
+
+    setIsNavGroupExpanded(false);
+    setIsDockExpandableExpanded(false);
+    setIsDockTextExpanded(false);
+    setIsDockExpanded(false);
   };
 
   const mobileTextLogo = (
@@ -205,7 +215,34 @@ export const NavDockedNav: React.FunctionComponent = () => {
         }, 200);
       }
     } else {
-      setIsDockTextExpanded(!isDockTextExpanded);
+      const nextDockTextExpanded = !isDockTextExpanded;
+      setIsDockTextExpanded(nextDockTextExpanded);
+
+      if (!nextDockTextExpanded) {
+        setIsDockExpandableExpanded(false);
+      }
+
+      if (isDockExpandableExpanded) {
+        setIsDockExpandableExpanded(false);
+        setIsDockTextExpanded(false);
+      }
+    }
+  };
+
+  const onToggleNavGroup = (
+    _event: React.MouseEvent<HTMLButtonElement>,
+    result: { groupId: number | string; isExpanded: boolean }
+  ) => {
+    setIsNavGroupExpanded(result.isExpanded);
+
+    if (!isMobile) {
+      if (!isDockExpandableExpanded && !isDockTextExpanded) {
+        setIsDockExpandableExpanded(true);
+      }
+
+      if (!isDockTextExpanded) {
+        setIsDockTextExpanded(false);
+      }
     }
   };
 
@@ -270,7 +307,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
         <Toolbar isVertical>
           <ToolbarContent>
             <ToolbarItem>
-              <Nav onSelect={onNavSelect} variant="docked" aria-label="Global">
+              <Nav onSelect={onNavSelect} onToggle={onToggleNavGroup} variant="docked" aria-label="Global">
                 <NavList>
                   <NavItem
                     preventDefault
@@ -278,12 +315,31 @@ export const NavDockedNav: React.FunctionComponent = () => {
                     to="#nav-link1"
                     itemId={0}
                     isActive={activeItem === 0}
-                    icon={<CubeIcon />}
+                    icon={<RhUiCubesIcon />}
                     anchorRef={navItem1Ref}
                     aria-label="System panel"
                   >
                     System panel
                   </NavItem>
+                  <NavExpandable
+                    title="Policy"
+                    groupId={4}
+                    isExpanded={isNavGroupExpanded}
+                    icon={<RhUiFolderIcon />}
+                    hasExpandableIcon={!isMobile}
+                  >
+                    <NavItem
+                      preventDefault
+                      id="expandable3rd-1"
+                      to="#expandable3rd-1"
+                      groupId="nav-expand3rd-group-1"
+                      itemId={5}
+                      isActive={activeItem === 5}
+                      icon={<RhUiResourceIcon />}
+                    >
+                      Subnav link 1
+                    </NavItem>
+                  </NavExpandable>
                   <NavItem
                     preventDefault
                     id="nav-link2"
@@ -428,6 +484,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
       <Page
         variant="docked"
         isDockExpanded={isDockExpanded}
+        isDockExpandableExpanded={isDockExpandableExpanded}
         isDockTextExpanded={isDockTextExpanded}
         masthead={mobileMasthead}
         dockContent={dockedMasthead}

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -271,7 +271,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
   };
 
   const onToggleNavGroup = (_event: React.MouseEvent<HTMLButtonElement>, isExpanded: boolean) => {
-    if (!isDockExpandableExpanded) {
+    if (!isDockExpandableExpanded && !isDockTextExpanded && !isDockExpanded) {
       setIsNavGroupExpanded(true);
     } else {
       setIsNavGroupExpanded(isExpanded);

--- a/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDockedNav.tsx
@@ -114,7 +114,6 @@ export const NavDockedNav: React.FunctionComponent = () => {
   const onNavSelect = (_event: React.FormEvent<HTMLInputElement>, selectedItem: NavOnSelectProps) => {
     typeof selectedItem.itemId === 'number' && setActiveItem(selectedItem.itemId);
 
-    setIsNavGroupExpanded(false);
     setIsDockExpandableExpanded(false);
     setIsDockTextExpanded(false);
     setIsDockExpanded(false);
@@ -271,11 +270,12 @@ export const NavDockedNav: React.FunctionComponent = () => {
     }
   };
 
-  const onToggleNavGroup = (
-    _event: React.MouseEvent<HTMLButtonElement>,
-    result: { groupId: number | string; isExpanded: boolean }
-  ) => {
-    setIsNavGroupExpanded(result.isExpanded);
+  const onToggleNavGroup = (_event: React.MouseEvent<HTMLButtonElement>, isExpanded: boolean) => {
+    if (!isDockExpandableExpanded) {
+      setIsNavGroupExpanded(true);
+    } else {
+      setIsNavGroupExpanded(isExpanded);
+    }
 
     if (!isMobile) {
       if (!isDockExpandableExpanded && !isDockTextExpanded) {
@@ -350,7 +350,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
         <Toolbar isVertical>
           <ToolbarContent>
             <ToolbarItem>
-              <Nav onSelect={onNavSelect} onToggle={onToggleNavGroup} variant="docked" aria-label="Global">
+              <Nav onSelect={onNavSelect} variant="docked" aria-label="Global">
                 <NavList>
                   <NavItem
                     preventDefault
@@ -371,6 +371,7 @@ export const NavDockedNav: React.FunctionComponent = () => {
                     icon={<RhUiFolderIcon />}
                     hasExpandableIcon={!isMobile}
                     buttonProps={{ ref: navItem5Ref, 'aria-label': 'Folder' }}
+                    onExpand={onToggleNavGroup}
                   >
                     <NavItem
                       preventDefault

--- a/packages/react-core/src/helpers/index.ts
+++ b/packages/react-core/src/helpers/index.ts
@@ -14,3 +14,4 @@ export * from './KeyboardHandler';
 export * from './resizeObserver';
 export * from './useInterval';
 export * from './datetimeUtils';
+export * from './inert';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5171,7 +5171,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
+<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
+=======
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
+>>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -5192,7 +5196,11 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.40.0"
+<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
+=======
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
+>>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     "@patternfly/patternfly-a11y": "npm:5.2.1"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -5232,7 +5240,11 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
+<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
+=======
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
+>>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     "@rhds/icons": "npm:^2.2.0"
     fs-extra: "npm:^11.3.3"
     tslib: "npm:^2.8.1"
@@ -5319,7 +5331,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
+<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
+=======
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
+>>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
@@ -5361,7 +5377,11 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.4"
+<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
+=======
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
+>>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     fs-extra: "npm:^11.3.3"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5171,11 +5171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
-=======
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
->>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -5196,11 +5192,7 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.40.0"
-<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
-=======
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
->>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     "@patternfly/patternfly-a11y": "npm:5.2.1"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -5240,11 +5232,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
-=======
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
->>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     "@rhds/icons": "npm:^2.2.0"
     fs-extra: "npm:^11.3.3"
     tslib: "npm:^2.8.1"
@@ -5331,11 +5319,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
-=======
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
->>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
@@ -5377,11 +5361,7 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.4"
-<<<<<<< HEAD
     "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
-=======
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.37"
->>>>>>> 18312a983d (feat(Nav,Compass,Page): add support for expandable nav items in docked nav)
     fs-extra: "npm:^11.3.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12556

Also fixes #12629

* Adds `isDockExpandableExpanded` to Page & Compass
* Adds `hasExpandableIcon` to NavExpandable
* Adds docked nav example to Nav examples
* Updates docked nav demos in Nav and Compass to include an expandable nav item & updates expand/collapse logic
* Adds tests for new props
* Fixes missing export for IS_INERT helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable dock support for Compass and Page layouts.
  * Added optional expandable icons to navigation groups.
  * Added docked navigation examples with selectable links, expandable groups, and nested items.
  * Improved dock interactions, including click-outside and Escape-key dismissal.
  * Updated navigation demos with refreshed icons and responsive behavior.

* **Documentation**
  * Expanded navigation documentation with docked variant guidance and usage examples.

* **Bug Fixes**
  * Corrected Compass property documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->