### PR TITLE
feat(Page): Add PageHeader component

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.6.0-prerelease.20",
+    "@patternfly/patternfly": "6.6.0-prerelease.39",
     "case-anything": "^3.1.2",
     "css": "^3.0.0",
     "fs-extra": "^11.3.3"

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -28,7 +28,10 @@ export interface PageProps extends React.HTMLProps<HTMLDivElement> {
    * will handle toggling the visibility of the text in individual isDocked components.
    */
   isDockTextExpanded?: boolean;
-  /** The horizontal masthead content (e.g. <Masthead />). When using the docked variant, this content will only render at mobile viewports. */
+  /** The horizontal masthead content (e.g. <Masthead /> or <PageHeader />). PageHeader is an alternative to Masthead
+   * and can wrap a Masthead or custom header content. When using the docked variant, this content will only render at
+   * mobile viewports.
+   */
   masthead?: React.ReactNode;
   /** @beta Content to render in the vertical dock when variant of docked is used. At mobile viewports, this content will be replaced with the content passed to masthead. */
   dockContent?: React.ReactNode;

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -29,7 +29,7 @@ export interface PageProps extends React.HTMLProps<HTMLDivElement> {
    */
   isDockTextExpanded?: boolean;
   /** The horizontal masthead content (e.g. <Masthead /> or <PageHeader />). PageHeader is an alternative to Masthead
-   * and can wrap a Masthead or custom header content. When using the docked variant, this content will only render at
+   * and should only be used to wrap custom header content. When using the docked variant, this content will only render at
    * mobile viewports.
    */
   masthead?: React.ReactNode;

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -2,7 +2,7 @@ import styles from '@patternfly/react-styles/css/components/Page/page';
 import { css } from '@patternfly/react-styles';
 
 export interface PageHeaderProps extends React.HTMLProps<HTMLElement> {
-  /** Content rendered inside the page header. This can be a Masthead or custom header content. */
+  /** Content rendered inside the page header. This should be custom header content, rather than the PatternFly Masthead. */
   children?: React.ReactNode;
   /** Additional classes added to the page header */
   className?: string;

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -1,0 +1,28 @@
+import styles from '@patternfly/react-styles/css/components/Page/page';
+import { css } from '@patternfly/react-styles';
+
+export interface PageHeaderProps extends React.HTMLProps<HTMLElement> {
+  /** Content rendered inside the page header. This can be a Masthead or custom header content. */
+  children?: React.ReactNode;
+  /** Additional classes added to the page header */
+  className?: string;
+  /** Sets the base component to render. Defaults to div */
+  component?: keyof React.JSX.IntrinsicElements;
+}
+
+export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
+  className,
+  children,
+  component = 'div',
+  ...props
+}: PageHeaderProps) => {
+  const Component = component as any;
+
+  return (
+    <Component {...props} className={css(styles.pageHeader, className)}>
+      {children}
+    </Component>
+  );
+};
+
+PageHeader.displayName = 'PageHeader';

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -6,14 +6,14 @@ export interface PageHeaderProps extends React.HTMLProps<HTMLElement> {
   children?: React.ReactNode;
   /** Additional classes added to the page header */
   className?: string;
-  /** Sets the base component to render. Defaults to div */
+  /** Sets the base component to render. Defaults to header */
   component?: keyof React.JSX.IntrinsicElements;
 }
 
 export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   className,
   children,
-  component = 'div',
+  component = 'header',
   ...props
 }: PageHeaderProps) => {
   const Component = component as any;

--- a/packages/react-core/src/components/Page/__tests__/Page.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/Page.test.tsx
@@ -500,21 +500,4 @@ describe('Page docked variant', () => {
     expect(header).toHaveClass(styles.pageHeader);
     expect(header.parentElement).toHaveClass(styles.page);
   });
-
-  test('Renders Masthead inside PageHeader when passed to the masthead prop', () => {
-    render(
-      <Page
-        {...props}
-        masthead={
-          <PageHeader>
-            <Masthead>Logo</Masthead>
-          </PageHeader>
-        }
-      >
-        <PageSection>Custom content</PageSection>
-      </Page>
-    );
-
-    expect(screen.getByText('Logo').closest(`.${styles.pageHeader}`)).toBeInTheDocument();
-  });
 });

--- a/packages/react-core/src/components/Page/__tests__/Page.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/Page.test.tsx
@@ -9,6 +9,7 @@ import { Nav, NavList, NavItem } from '../../Nav';
 import { SkipToContent } from '../../SkipToContent';
 import { PageBreadcrumb } from '../PageBreadcrumb';
 import { PageGroup } from '../PageGroup';
+import { PageHeader } from '../PageHeader';
 import { Masthead } from '../../Masthead';
 
 import styles from '@patternfly/react-styles/css/components/Page/page';
@@ -486,5 +487,34 @@ describe('Page docked variant', () => {
 
     const pageDockMain = screen.getByText('Dock content').closest(`.${styles.pageDockMain}`);
     expect(pageDockMain).toBeInTheDocument();
+  });
+
+  test('Renders PageHeader when passed to the masthead prop', () => {
+    render(
+      <Page {...props} masthead={<PageHeader>Custom header</PageHeader>}>
+        <PageSection>Custom content</PageSection>
+      </Page>
+    );
+
+    const header = screen.getByText('Custom header');
+    expect(header).toHaveClass(styles.pageHeader);
+    expect(header.parentElement).toHaveClass(styles.page);
+  });
+
+  test('Renders Masthead inside PageHeader when passed to the masthead prop', () => {
+    render(
+      <Page
+        {...props}
+        masthead={
+          <PageHeader>
+            <Masthead>Logo</Masthead>
+          </PageHeader>
+        }
+      >
+        <PageSection>Custom content</PageSection>
+      </Page>
+    );
+
+    expect(screen.getByText('Logo').closest(`.${styles.pageHeader}`)).toBeInTheDocument();
   });
 });

--- a/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
@@ -9,17 +9,17 @@ test('Renders children', () => {
 
 test(`Renders with class ${styles.pageHeader} by default`, () => {
   render(<PageHeader>Header content</PageHeader>);
-  expect(screen.getByText('Header content')).toHaveClass(styles.pageHeader);
+  expect(screen.getByText('Header content')).toHaveClass(styles.pageHeader, { exact: true });
 });
 
 test('Renders as a div by default', () => {
   render(<PageHeader>Header content</PageHeader>);
-  expect(screen.getByText('Header content').tagName).toBe('DIV');
+  expect(screen.getByText('Header content').tagName).toBe('HEADER');
 });
 
 test('Renders as a custom component when component is passed', () => {
-  render(<PageHeader component="header">Header content</PageHeader>);
-  expect(screen.getByText('Header content').tagName).toBe('HEADER');
+  render(<PageHeader component="div">Header content</PageHeader>);
+  expect(screen.getByText('Header content').tagName).toBe('DIV');
 });
 
 test('Renders with custom classes when className is passed', () => {

--- a/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import styles from '@patternfly/react-styles/css/components/Page/page';
+import { PageHeader } from '../PageHeader';
+
+test('Renders children', () => {
+  render(<PageHeader>Header content</PageHeader>);
+  expect(screen.getByText('Header content')).toBeVisible();
+});
+
+test(`Renders with class ${styles.pageHeader} by default`, () => {
+  render(<PageHeader>Header content</PageHeader>);
+  expect(screen.getByText('Header content')).toHaveClass(styles.pageHeader);
+});
+
+test('Renders as a div by default', () => {
+  render(<PageHeader>Header content</PageHeader>);
+  expect(screen.getByText('Header content').tagName).toBe('DIV');
+});
+
+test('Renders as a custom component when component is passed', () => {
+  render(<PageHeader component="header">Header content</PageHeader>);
+  expect(screen.getByText('Header content').tagName).toBe('HEADER');
+});
+
+test('Renders with custom classes when className is passed', () => {
+  render(<PageHeader className="custom-class">Header content</PageHeader>);
+  expect(screen.getByText('Header content')).toHaveClass('custom-class');
+});
+
+test('Renders with spread props', () => {
+  render(<PageHeader id="custom-id">Header content</PageHeader>);
+  expect(screen.getByText('Header content')).toHaveAttribute('id', 'custom-id');
+});

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -3,7 +3,16 @@ id: Page
 section: components
 cssPrefix: pf-v6-c-page
 propComponents:
-  ['Page', 'PageSidebar', 'PageSidebarBody', 'PageSection', 'PageGroup', 'PageBreadcrumb', 'PageToggleButton']
+  [
+    'Page',
+    'PageHeader',
+    'PageSidebar',
+    'PageSidebarBody',
+    'PageSection',
+    'PageGroup',
+    'PageBreadcrumb',
+    'PageToggleButton'
+  ]
 ---
 
 import { useState, useLayoutEffect, useRef } from 'react';
@@ -16,13 +25,21 @@ import pageSectionWidthLimitMaxWidth from '@patternfly/react-tokens/dist/esm/c_p
 
 A page will typically contain the following components:
 
-- A `<Page>` with a `masthead` prop that often contains a [masthead](/components/masthead) component
+- A `<Page>` with a `masthead` prop that often contains a [masthead](/components/masthead) or a `<PageHeader>`
 
 The `<MastheadMain>` component includes the smaller area that typically contains the `<MastheadToggle>` and a `<MastheadLogo>`. `<MastheadContent>` represents the main portion of the masthead, and will typically contain a `<Toolbar>` or other menu-like components, like a `<Dropdown>`.
 
 - Mastheads contain a `<MastheadMain>` component, which includes the `<MastheadToggle>`, a `<MastheadLogo>`, and the page's toolbar (via `<MastheadContent>`.) The `<MastheadToggle>` component contains a `<PageToggleButton>`, and the `<MastheadLogo>` component contains a `<MastheadBrand>`.
 - 1 or more `<PageSidebarBody>` components inside `<PageSidebar>` for vertical navigation or other sidebar content
 - 1 or more `<PageSection>` components
+
+### Page header
+
+To use a page header instead of passing a [masthead](/components/masthead) directly, pass a `<PageHeader>` to the `masthead` property. `<PageHeader>` can wrap a `<Masthead>` or custom header content.
+
+```ts file="./PageHeaderContent.tsx"
+
+```
 
 ### Vertical navigation
 

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -35,7 +35,7 @@ The `<MastheadMain>` component includes the smaller area that typically contains
 
 ### Page header
 
-To use a page header instead of passing a [masthead](/components/masthead) directly, pass a `<PageHeader>` to the `masthead` property. `<PageHeader>` can wrap a `<Masthead>` or custom header content.
+To use a page header instead of passing a [masthead](/components/masthead) directly, pass a `<PageHeader>` to the `masthead` property. `<PageHeader>` should only be used to wrap custom header content.
 
 ```ts file="./PageHeaderContent.tsx"
 

--- a/packages/react-core/src/components/Page/examples/PageHeaderContent.tsx
+++ b/packages/react-core/src/components/Page/examples/PageHeaderContent.tsx
@@ -1,0 +1,52 @@
+import {
+  Page,
+  PageHeader,
+  Masthead,
+  MastheadMain,
+  MastheadBrand,
+  MastheadLogo,
+  MastheadContent,
+  PageSection,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
+} from '@patternfly/react-core';
+
+export const PageHeaderContent: React.FunctionComponent = () => {
+  const headerToolbar = (
+    <Toolbar id="page-header-content-toolbar">
+      <ToolbarContent>
+        <ToolbarItem>header-tools</ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  const pageHeader = (
+    <PageHeader>
+      <Masthead>
+        <MastheadMain>
+          <MastheadBrand>
+            <MastheadLogo href="https://patternfly.org" target="_blank">
+              Logo
+            </MastheadLogo>
+          </MastheadBrand>
+        </MastheadMain>
+        <MastheadContent>{headerToolbar}</MastheadContent>
+      </Masthead>
+    </PageHeader>
+  );
+
+  return (
+    <Page masthead={pageHeader}>
+      <PageSection aria-labelledby="section-1">
+        <h2 id="section-1">Page header example section 1</h2>
+      </PageSection>
+      <PageSection variant="secondary" aria-labelledby="section-2">
+        <h2 id="section-2">Page header example section 2 with secondary variant styling</h2>
+      </PageSection>
+      <PageSection aria-labelledby="section-3">
+        <h2 id="section-3">Page header example section 3</h2>
+      </PageSection>
+    </Page>
+  );
+};

--- a/packages/react-core/src/components/Page/examples/PageHeaderContent.tsx
+++ b/packages/react-core/src/components/Page/examples/PageHeaderContent.tsx
@@ -1,51 +1,18 @@
-import {
-  Page,
-  PageHeader,
-  Masthead,
-  MastheadMain,
-  MastheadBrand,
-  MastheadLogo,
-  MastheadContent,
-  PageSection,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem
-} from '@patternfly/react-core';
+import { Page, PageHeader, PageSection } from '@patternfly/react-core';
 
 export const PageHeaderContent: React.FunctionComponent = () => {
-  const headerToolbar = (
-    <Toolbar id="page-header-content-toolbar">
-      <ToolbarContent>
-        <ToolbarItem>header-tools</ToolbarItem>
-      </ToolbarContent>
-    </Toolbar>
-  );
-
-  const pageHeader = (
-    <PageHeader>
-      <Masthead>
-        <MastheadMain>
-          <MastheadBrand>
-            <MastheadLogo href="https://patternfly.org" target="_blank">
-              Logo
-            </MastheadLogo>
-          </MastheadBrand>
-        </MastheadMain>
-        <MastheadContent>{headerToolbar}</MastheadContent>
-      </Masthead>
-    </PageHeader>
-  );
+  const pageHeader = <PageHeader>Page header</PageHeader>;
 
   return (
     <Page masthead={pageHeader}>
-      <PageSection aria-labelledby="section-1">
-        <h2 id="section-1">Page header example section 1</h2>
+      <PageSection aria-labelledby="header-example-section-1">
+        <h2 id="header-example-section-1">Page header example section 1</h2>
       </PageSection>
-      <PageSection variant="secondary" aria-labelledby="section-2">
-        <h2 id="section-2">Page header example section 2 with secondary variant styling</h2>
+      <PageSection variant="secondary" aria-labelledby="header-example-section-2">
+        <h2 id="header-example-section-2">Page header example section 2 with secondary variant styling</h2>
       </PageSection>
-      <PageSection aria-labelledby="section-3">
-        <h2 id="section-3">Page header example section 3</h2>
+      <PageSection aria-labelledby="header-example-section-3">
+        <h2 id="header-example-section-3">Page header example section 3</h2>
       </PageSection>
     </Page>
   );

--- a/packages/react-core/src/components/Page/index.ts
+++ b/packages/react-core/src/components/Page/index.ts
@@ -2,6 +2,7 @@ export * from './Page';
 export * from './PageBody';
 export * from './PageBreadcrumb';
 export * from './PageGroup';
+export * from './PageHeader';
 export * from './PageSidebar';
 export * from './PageSidebarBody';
 export * from './PageSection';

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.6.0-prerelease.20",
+    "@patternfly/patternfly": "6.6.0-prerelease.39",
     "@patternfly/react-charts": "workspace:^",
     "@patternfly/react-code-editor": "workspace:^",
     "@patternfly/react-core": "workspace:^",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@patternfly/patternfly": "6.6.0-prerelease.20",
+    "@patternfly/patternfly": "6.6.0-prerelease.39",
     "@rhds/icons": "^2.2.0",
     "fs-extra": "^11.3.3"
   },

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.6.0-prerelease.20",
+    "@patternfly/patternfly": "6.6.0-prerelease.39",
     "change-case": "^5.4.4",
     "fs-extra": "^11.3.3"
   },

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@adobe/css-tools": "^4.4.4",
-    "@patternfly/patternfly": "6.6.0-prerelease.20",
+    "@patternfly/patternfly": "6.6.0-prerelease.39",
     "fs-extra": "^11.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5070,10 +5070,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:6.6.0-prerelease.20":
-  version: 6.6.0-prerelease.20
-  resolution: "@patternfly/patternfly@npm:6.6.0-prerelease.20"
-  checksum: 10c0/6bcc0015bb994ff29b6bdb66b7b83e8e91d8ea94278264c985bf40326b084c6c44606e4224f348e646d0e20b9545c4ffa4de6a1d33f697bf5f6f76fa74202951
+"@patternfly/patternfly@npm:6.6.0-prerelease.39":
+  version: 6.6.0-prerelease.39
+  resolution: "@patternfly/patternfly@npm:6.6.0-prerelease.39"
+  checksum: 10c0/e3ad085429507c23912bf50b84a178c9b2f05fe58dbbecce9eb76be9f70eb4b116e81a611f5eaa8dc388d4081ae5f36ab09725268041e5557a85c20cb07200c3
   languageName: node
   linkType: hard
 
@@ -5171,7 +5171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.20"
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -5192,7 +5192,7 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.40.0"
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.20"
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
     "@patternfly/patternfly-a11y": "npm:5.2.1"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -5232,7 +5232,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.20"
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
     "@rhds/icons": "npm:^2.2.0"
     fs-extra: "npm:^11.3.3"
     tslib: "npm:^2.8.1"
@@ -5319,7 +5319,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.20"
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
@@ -5361,7 +5361,7 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.4"
-    "@patternfly/patternfly": "npm:6.6.0-prerelease.20"
+    "@patternfly/patternfly": "npm:6.6.0-prerelease.39"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
PageHeader can be used to wrap masthead or hold a third-party custom header.

Fixes https://github.com/patternfly/patternfly-react/issues/12624

Assisted-by: Cursor

Tried to get it consistent with https://github.com/patternfly/patternfly/pull/8567, but let me know if I'm missing something here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable page header component for custom header content.
  - Supports configurable HTML elements, CSS classes, child content, and additional properties.
  - Exported the component as part of the Page API.

- **Documentation**
  - Clarified that page headers wrap custom content rather than a masthead.
  - Added an example demonstrating a custom page header with masthead and toolbar content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->