### PR TITLE
feat(Table): add composable sticky footer

### DIFF
--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -58,6 +58,8 @@ export interface TableProps extends React.HTMLProps<HTMLTableElement>, OUIAProps
   isStickyHeaderBase?: boolean;
   /** @beta Flag indicating the table header should have stuck styling, when the header is not at the top of the scroll container. */
   isStickyHeaderStuck?: boolean;
+  /** Flag indicating the table footer should stick to the bottom of its scroll container. */
+  isStickyFooter?: boolean;
   /** @hide Forwarded ref */
   innerRef?: React.RefObject<any>;
   /** Flag indicating table is a tree table */
@@ -104,6 +106,7 @@ const TableBase: React.FunctionComponent<TableProps> = ({
   isStickyHeader = false,
   isStickyHeaderBase = false,
   isStickyHeaderStuck = false,
+  isStickyFooter = false,
   isPlain = false,
   isNoPlainOnGlass = false,
   gridBreakPoint = TableGridBreakpoint.gridMd,
@@ -233,6 +236,7 @@ const TableBase: React.FunctionComponent<TableProps> = ({
           isStickyHeader && styles.modifiers.stickyHeader,
           isStickyHeaderBase && styles.modifiers.stickyHeaderBase,
           isStickyHeaderStuck && styles.modifiers.stickyHeaderStuck,
+          isStickyFooter && styles.modifiers.stickyFooter,
           isTreeTable && stylesTreeView.modifiers.treeView,
           isStriped && styles.modifiers.striped,
           isExpandable && styles.modifiers.expandable,

--- a/packages/react-table/src/components/Table/Tfoot.tsx
+++ b/packages/react-table/src/components/Table/Tfoot.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+
+export interface TfootProps extends React.HTMLProps<HTMLTableSectionElement> {
+  /** Content rendered inside the <tfoot> row group */
+  children?: React.ReactNode;
+  /** Additional classes added to the <tfoot> element */
+  className?: string;
+  /** @hide Forwarded ref */
+  innerRef?: React.Ref<any>;
+}
+
+const TfootBase: React.FunctionComponent<TfootProps> = ({ children, className, innerRef, ...props }: TfootProps) => (
+  <tfoot className={css(styles.tableTfoot, className)} ref={innerRef} {...props}>
+    {children}
+  </tfoot>
+);
+
+export const Tfoot = forwardRef((props: TfootProps, ref: React.Ref<HTMLTableSectionElement>) => (
+  <TfootBase {...props} innerRef={ref} />
+));
+Tfoot.displayName = 'Tfoot';

--- a/packages/react-table/src/components/Table/__tests__/Table.test.tsx
+++ b/packages/react-table/src/components/Table/__tests__/Table.test.tsx
@@ -222,3 +222,15 @@ test(`Does not render with class ${styles.modifiers.stickyHeaderStuck} when isSt
 
   expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.stickyHeaderStuck);
 });
+
+test(`Renders with class ${styles.modifiers.stickyFooter} when isStickyFooter is true`, () => {
+  render(<Table isStickyFooter aria-label="Test table" />);
+
+  expect(screen.getByRole('grid', { name: 'Test table' })).toHaveClass(styles.modifiers.stickyFooter);
+});
+
+test(`Does not render with class ${styles.modifiers.stickyFooter} when isStickyFooter is false`, () => {
+  render(<Table isStickyFooter={false} aria-label="Test table" />);
+
+  expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.stickyFooter);
+});

--- a/packages/react-table/src/components/Table/__tests__/Tfoot.test.tsx
+++ b/packages/react-table/src/components/Table/__tests__/Tfoot.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { Tfoot } from '../Tfoot';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+
+test('Renders a tfoot element with the table footer class', () => {
+  render(
+    <table>
+      <Tfoot>
+        <tr>
+          <td>Footer</td>
+        </tr>
+      </Tfoot>
+    </table>
+  );
+
+  expect(screen.getByText('Footer').closest('tfoot')).toHaveClass(styles.tableTfoot);
+});
+
+test('Forwards props, class names, and refs to the tfoot element', () => {
+  const ref = { current: null } as React.RefObject<HTMLTableSectionElement>;
+
+  render(
+    <table>
+      <Tfoot ref={ref} className="custom-footer" data-testid="footer">
+        <tr />
+      </Tfoot>
+    </table>
+  );
+
+  expect(screen.getByTestId('footer')).toHaveClass(styles.tableTfoot, 'custom-footer');
+  expect(ref.current).toBe(screen.getByTestId('footer'));
+});

--- a/packages/react-table/src/components/Table/__tests__/Tfoot.test.tsx
+++ b/packages/react-table/src/components/Table/__tests__/Tfoot.test.tsx
@@ -2,31 +2,64 @@ import { render, screen } from '@testing-library/react';
 import { Tfoot } from '../Tfoot';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
-test('Renders a tfoot element with the table footer class', () => {
+test('Renders without children', () => {
   render(
     <table>
-      <Tfoot>
-        <tr>
-          <td>Footer</td>
-        </tr>
-      </Tfoot>
+      <Tfoot />
     </table>
   );
 
-  expect(screen.getByText('Footer').closest('tfoot')).toHaveClass(styles.tableTfoot);
+  expect(screen.getByRole('rowgroup')).toBeInTheDocument();
 });
 
-test('Forwards props, class names, and refs to the tfoot element', () => {
+test('Renders with children', () => {
+  render(
+    <table>
+      <Tfoot>Footer content</Tfoot>
+    </table>
+  );
+
+  expect(screen.getByRole('rowgroup')).toHaveTextContent('Footer content');
+});
+
+test(`Renders with class ${styles.tableTfoot} only by default`, () => {
+  render(
+    <table>
+      <Tfoot />
+    </table>
+  );
+
+  expect(screen.getByRole('rowgroup')).toHaveClass(styles.tableTfoot, { exact: true });
+});
+
+test('Forwards refs to the tfoot element', () => {
   const ref = { current: null } as React.RefObject<HTMLTableSectionElement>;
 
   render(
     <table>
-      <Tfoot ref={ref} className="custom-footer" data-testid="footer">
-        <tr />
-      </Tfoot>
+      <Tfoot ref={ref} />
     </table>
   );
 
-  expect(screen.getByTestId('footer')).toHaveClass(styles.tableTfoot, 'custom-footer');
-  expect(ref.current).toBe(screen.getByTestId('footer'));
+  expect(ref.current).toBe(screen.getByRole('rowgroup'));
+});
+
+test('Renders with custom class names provided via prop', () => {
+  render(
+    <table>
+      <Tfoot className="custom-footer" />
+    </table>
+  );
+
+  expect(screen.getByRole('rowgroup')).toHaveClass('custom-footer');
+});
+
+test('Spreads additional props', () => {
+  render(
+    <table>
+      <Tfoot data-custom="true" />
+    </table>
+  );
+
+  expect(screen.getByRole('rowgroup')).toHaveAttribute('data-custom', 'true');
 });

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -10,6 +10,7 @@ propComponents:
     'Tr',
     'Th',
     'Td',
+    'Tfoot',
     'Caption',
     'TableText',
     'TdActionsType',
@@ -477,6 +478,14 @@ The second `Tr` represents the second level of sub columns. The `Th` in this row
 ### Nested sticky header
 
 ```ts file="TableNestedStickyHeader.tsx"
+
+```
+
+### Sticky footer
+
+Use `Tfoot` for semantic table footer rows. Set `isStickyFooter` on `Table` to keep the footer visible while its scroll container is scrolling.
+
+```ts file="TableStickyFooter.tsx"
 
 ```
 

--- a/packages/react-table/src/components/Table/examples/TableStickyFooter.tsx
+++ b/packages/react-table/src/components/Table/examples/TableStickyFooter.tsx
@@ -6,7 +6,7 @@ export const TableStickyFooter: React.FunctionComponent = () => {
   return (
     <div style={{ height: '400px' }}>
       <InnerScrollContainer>
-        <Table aria-label="Sticky footer table" gridBreakPoint="" isStickyFooter>
+        <Table aria-label="Sticky footer table" isStickyFooter>
           <Thead>
             <Tr>
               <Th>Item</Th>

--- a/packages/react-table/src/components/Table/examples/TableStickyFooter.tsx
+++ b/packages/react-table/src/components/Table/examples/TableStickyFooter.tsx
@@ -1,0 +1,33 @@
+import { Table, Thead, Tfoot, Tr, Th, Tbody, Td, InnerScrollContainer } from '@patternfly/react-table';
+
+export const TableStickyFooter: React.FunctionComponent = () => {
+  const rows = Array.from({ length: 12 }, (_, index) => index + 1);
+
+  return (
+    <div style={{ height: '400px' }}>
+      <InnerScrollContainer>
+        <Table aria-label="Sticky footer table" gridBreakPoint="" isStickyFooter>
+          <Thead>
+            <Tr>
+              <Th>Item</Th>
+              <Th>Value</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {rows.map((row) => (
+              <Tr key={row}>
+                <Td dataLabel="Item">Item {row}</Td>
+                <Td dataLabel="Value">Value {row}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+          <Tfoot>
+            <Tr>
+              <Td colSpan={2}>Total: {rows.length} items</Td>
+            </Tr>
+          </Tfoot>
+        </Table>
+      </InnerScrollContainer>
+    </div>
+  );
+};

--- a/packages/react-table/src/components/Table/index.ts
+++ b/packages/react-table/src/components/Table/index.ts
@@ -16,6 +16,7 @@ export * from './TreeRowWrapper';
 export * from './Table';
 export * from './Thead';
 export * from './Tbody';
+export * from './Tfoot';
 export * from './Tr';
 export * from './Th';
 export * from './Td';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Adds support for composable sticky table footers.

**Jira**: [PF-3996](https://redhat.atlassian.net/browse/PF-3996)

- Adds a composable `Tfoot` component for semantic table footer rows.
- Adds the `isStickyFooter` prop to `Table`.
- Exports `Tfoot` from `@patternfly/react-table`.
- Adds documentation and a sticky footer example.
- Adds unit tests for `Tfoot` and sticky footer behavior.

**Validation**:

- `yarn jest packages/react-table/src/components/Table/__tests__/Table.test.tsx packages/react-table/src/components/Table/__tests__/Tfoot.test.tsx --runInBand`
- `yarn tsc --build packages/tsconfig.json --pretty false`

Both checks passed.

**Additional issues**: None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sticky table footers through the `isStickyFooter` property.
  * Added a reusable table footer component for semantic table layouts, including ref forwarding and custom properties.
  * Exported the table footer component for public use.
  * Added support for displaying summary content, such as totals, in table footers.

* **Documentation**
  * Added a sticky footer example and documented the new table footer component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

GitHub: https://github.com/patternfly/patternfly-react/issues/12354