### PR TITLE
fix(Label): reset edit state when canceling with escape

### DIFF
--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -205,9 +205,8 @@ export const Label: React.FunctionComponent<LabelProps> = ({
       if (isEditableActive && key === 'Escape') {
         event.preventDefault();
         event.stopImmediatePropagation();
-        // Reset div text to initial children prop - pre-edit
+        setCurrValue(children);
         if (editableInputRef.current.value) {
-          editableInputRef.current.value = children as string;
           onEditCancel && onEditCancel(event, children as string);
         }
         setIsEditableActive(false);

--- a/packages/react-core/src/components/Label/__tests__/Label.test.tsx
+++ b/packages/react-core/src/components/Label/__tests__/Label.test.tsx
@@ -109,6 +109,44 @@ describe('Label', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('editable label discards the draft text when the edit is canceled with escape', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Label onEditCancel={jest.fn()} onEditComplete={jest.fn()} isEditable>
+        Something
+      </Label>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Something' }));
+    await user.type(screen.getByRole('textbox'), ' else');
+    expect(screen.getByRole('textbox')).toHaveValue('Something else');
+
+    await user.keyboard('{Escape}');
+    expect(screen.getByRole('button', { name: 'Something' })).toBeInTheDocument();
+
+    // Reopening the editor must show the original text, not the discarded draft
+    await user.click(screen.getByRole('button', { name: 'Something' }));
+    expect(screen.getByRole('textbox')).toHaveValue('Something');
+  });
+
+  test('editable label calls onEditCancel with the previous text when the edit is canceled with escape', async () => {
+    const user = userEvent.setup();
+    const onEditCancel = jest.fn();
+
+    render(
+      <Label onEditCancel={onEditCancel} isEditable>
+        Something
+      </Label>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Something' }));
+    await user.type(screen.getByRole('textbox'), ' else');
+    await user.keyboard('{Escape}');
+
+    expect(onEditCancel).toHaveBeenCalledWith(expect.anything(), 'Something');
+  });
+
   test('renders with variant overflow and type is set to button ', () => {
     const { asFragment } = render(<Label variant="overflow">Something</Label>);
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button');


### PR DESCRIPTION
**What**: Closes #12648

Pressing Escape during an inline label edit reverts the displayed text, but reopening the editor brings back the discarded draft.

The edit input is controlled by `currValue`, and the Escape handler was resetting the DOM node directly:

```js
editableInputRef.current.value = children as string;
```

That has no effect on a controlled input, so `currValue` kept the draft. The fix resets the state instead:

```js
setCurrValue(children);
```

This runs unconditionally, which also covers the case where the input is cleared before pressing Escape. Previously `currValue` stayed `''` while the label displayed the original text. `onEditCancel` keeps its existing guard, so the callback behavior is unchanged.

Added two tests: reopening the editor after Escape shows the original text, and `onEditCancel` receives the previous text. No snapshot changes.

**Additional issues**: None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed editable labels so pressing Escape reliably discards draft text and restores the original label value.
  - Ensured reopening the editor displays the restored value.
  - Preserved the edit-cancel callback behavior and previous-text argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->